### PR TITLE
Nub protocol for background server launch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,18 +2,37 @@ cmake_minimum_required(VERSION 3.12)
 
 project(xi)
 
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 include(CheckCXXCompilerFlag)
+include(CheckIncludeFile)
 
 check_cxx_compiler_flag("-pg" has_gprof "int main() { return 0; }")
 if (CMAKE_PROFILE AND has_gprof)
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg")
 endif()
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# check for the C thread support library
+find_package(Threads REQUIRED)
+check_include_file("threads.h" have_threads_h)
+#set(CMAKE_REQUIRED_LIBRARIES -pthread)
+set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+check_c_source_compiles("#include <threads.h>
+int main() { thrd_t t; thrd_create(&t, &main, NULL); }" has_thread_support)
+
+if(NOT has_thread_support)
+include_directories(src/compat)
+endif()
 
 include_directories(src)
 add_executable(xi src/xi.cc src/xi_nub.cc)
+target_link_libraries(xi ${CMAKE_THREAD_LIBS_INIT})
+
+add_executable(test_sem tests/test_sem.cc src/xi_nub.cc)
+target_link_libraries(test_sem ${CMAKE_THREAD_LIBS_INIT})
+add_test(test_sem test_sem)
 
 if (WIN32)
 set_source_files_properties(src/xi.cc src/xi_nub.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,4 +13,10 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include_directories(src)
-add_executable(xi src/xi.cc)
+add_executable(xi src/xi.cc src/xi_nub.cc)
+
+if (WIN32)
+set_source_files_properties(src/xi.cc src/xi_nub.cc
+	PROPERTIES COMPILE_DEFINITIONS _CRT_SECURE_NO_WARNINGS
+)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ add_executable(test_sem tests/test_sem.cc src/xi_nub.cc)
 target_link_libraries(test_sem ${CMAKE_THREAD_LIBS_INIT})
 add_test(test_sem test_sem)
 
+add_executable(test_exe tests/test_exe.cc)
+target_link_libraries(test_exe ${CMAKE_THREAD_LIBS_INIT})
+add_test(test_exe test_exe)
+
 if (WIN32)
 set_source_files_properties(src/xi.cc src/xi_nub.cc
 	PROPERTIES COMPILE_DEFINITIONS _CRT_SECURE_NO_WARNINGS

--- a/README.md
+++ b/README.md
@@ -53,3 +53,46 @@ are then used to find tokens in the hash table, which are collated then
 filtered using the boolean _and_ combination of terms. The filter step
 is needed because some token hits will refer to rows that only contain
 a subset of all query terms.
+
+
+## Nubs
+
+_Xi_ supports a concept called _nubs_ which are session process
+activation stubs. _Nubs_ allow a client to create a session peer
+process with a different lifecycle to its own, hence the name _nub_.
+Nubs allow splitting the app into a command-line agent and session
+peer containing some cache, with the session peer process automatically
+started by the command-line tool. Subsequent invocations of the tool will
+connect to a previously created session peer process.
+
+### Xi Unicdoe Nub
+
+_Xi_ uses nubs to create a process that caches the Rabin-Karp indices,
+to allow it to answer queries more quickly because the index has been
+cached. This makes subsequent invocations very fast. Queries in this
+way can be answered in less than a millisecond.
+
+_Example invocation of a search query using a 'nub-client':_
+
+```
+xi -t nub-client blue
+⻘	U+2ed8	CJK RADICAL BLUE
+⾭	U+2fad	KANGXI RADICAL BLUE
+💙	U+1f499	BLUE HEART
+📘	U+1f4d8	BLUE BOOK
+🔵	U+1f535	LARGE BLUE CIRCLE
+🔷	U+1f537	LARGE BLUE DIAMOND
+🔹	U+1f539	SMALL BLUE DIAMOND
+🟦	U+1f7e6	LARGE BLUE SQUARE
+🫐	U+1fad0	BLUEBERRIES
+[nub-client] search = 254μs
+```
+
+### Nub Locking
+
+Nubs use a locking protocol to ensure that only a single process is
+launched. When a nub clients attempt to connect to the server. if there
+is no answer they will create a semaphore, writing its id to a file,
+a leader will be chosen to fork the nub child process and all clients
+will then wait on their semaphore. When server has started, it will
+read the list of semaphores and signal them waking up all of the clients.

--- a/src/stdendian.h
+++ b/src/stdendian.h
@@ -1,0 +1,288 @@
+#pragma once
+
+/*
+ * stdendian.h
+ *
+ * This header defines the following endian macros as defined here:
+ *
+ *   http://austingroupbugs.net/view.php?id=162
+ *
+ *   BYTE_ORDER         this macro shall have a value equal to one
+ *                      of the *_ENDIAN macros in this header.
+ *   LITTLE_ENDIAN      if BYTE_ORDER == LITTLE_ENDIAN, the host
+ *                      byte order is from least significant to
+ *                      most significant.
+ *   BIG_ENDIAN         if BYTE_ORDER == BIG_ENDIAN, the host byte
+ *                      order is from most significant to least
+ *                      significant.
+ *
+ * This header also defines several byte-swap interfaces, some that
+ * map directly to the host byte swap intrinsics and some sensitive
+ * to the host endian representation, performing a swap only if the
+ * host representation differs from the chosen representation.
+ *
+ * Direct byte swapping interfaces:
+ *
+ *   uint16_t bswap16(uint16_t x); (* swap bytes 16-bit word *)
+ *   uint32_t bswap32(uint32_t x); (* swap bytes 32-bit word *)
+ *   uint64_t bswap64(uint32_t x); (* swap bytes 64-bit word *)
+ *
+ * Simplified host endian interfaces:
+ *
+ *   uint16_t be16(uint16_t x); (* big-endian representation 16-bit word *)
+ *   uint32_t be32(uint32_t x); (* big-endian representation 32-bit word *)
+ *   uint64_t be64(uint32_t x); (* big-endian representation 64-bit word *)
+ *
+ *   uint16_t le16(uint16_t x); (* little-endian representation 16-bit word *)
+ *   uint32_t le32(uint32_t x); (* little-endian representation 32-bit word *)
+ *   uint64_t le64(uint32_t x); (* little-endian representation 64-bit word *)
+ *
+ * BSD host endian interfaces:
+ *
+ *   uint16_t htobe16(uint16_t x) { return be16(x); }
+ *   uint16_t htole16(uint16_t x) { return le16(x); }
+ *   uint16_t be16toh(uint16_t x) { return be16(x); }
+ *   uint16_t le16toh(uint16_t x) { return le16(x); }
+ *
+ *   uint32_t htobe32(uint32_t x) { return be32(x); }
+ *   uint32_t htole32(uint32_t x) { return le32(x); }
+ *   uint32_t be32toh(uint32_t x) { return be32(x); }
+ *   uint32_t le32toh(uint32_t x) { return le32(x); }
+ *
+ *   uint64_t htobe64(uint32_t x) { return be64(x); }
+ *   uint64_t htole64(uint32_t x) { return le64(x); }
+ *   uint64_t be64toh(uint32_t x) { return be64(x); }
+ *   uint64_t le64toh(uint32_t x) { return le64(x); }
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Linux */
+#if defined(__linux__) || defined(__GLIBC__)
+#include <endian.h>
+#include <byteswap.h>
+#define __ENDIAN_DEFINED
+#define __BSWAP_DEFINED
+#define __HOSTSWAP_DEFINED
+#define _BYTE_ORDER             __BYTE_ORDER
+#define _LITTLE_ENDIAN          __LITTLE_ENDIAN
+#define _BIG_ENDIAN             __BIG_ENDIAN
+#define bswap16(x)              bswap_16(x)
+#define bswap32(x)              bswap_32(x)
+#define bswap64(x)              bswap_64(x)
+#endif /* __linux__ || __GLIBC__ */
+
+/* BSD */
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__DragonFly__) || defined(__OpenBSD__)
+#include <sys/endian.h>
+#define __ENDIAN_DEFINED
+#define __BSWAP_DEFINED
+#define __HOSTSWAP_DEFINED
+#endif /* BSD */
+
+/* Apple */
+#if defined(__APPLE__)
+#include <machine/endian.h>
+#define _BYTE_ORDER             BYTE_ORDER
+#define _LITTLE_ENDIAN          LITTLE_ENDIAN
+#define _BIG_ENDIAN             BIG_ENDIAN
+#define __ENDIAN_DEFINED
+#endif /* Apple */
+
+/* Windows */
+#if defined(_WIN32) || defined(_MSC_VER)
+/* assumes all Microsoft targets are little endian */
+#include <stdlib.h>
+#define _LITTLE_ENDIAN          1234
+#define _BIG_ENDIAN             4321
+#define _BYTE_ORDER             _LITTLE_ENDIAN
+#define __ENDIAN_DEFINED
+#define __BSWAP_DEFINED
+static inline uint16_t bswap16(uint16_t x) { return _byteswap_ushort(x); }
+static inline uint32_t bswap32(uint32_t x) { return _byteswap_ulong(x); }
+static inline uint64_t bswap64(uint64_t x) { return _byteswap_uint64(x); }
+#endif /* Windows */
+
+/* OpenCL */
+#if defined (__OPENCL_VERSION__)
+#define _LITTLE_ENDIAN          1234
+#define _BIG_ENDIAN             4321
+#if defined (__ENDIAN_LITTLE__)
+#define _BYTE_ORDER             _LITTLE_ENDIAN
+#else
+#define _BYTE_ORDER             _BIG_ENDIAN
+#endif
+#define bswap16(x)              as_ushort(as_uchar2(ushort(x)).s1s0)
+#define bswap32(x)              as_uint(as_uchar4(uint(x)).s3s2s1s0)
+#define bswap64(x)              as_ulong(as_uchar8(ulong(x)).s7s6s5s4s3s2s1s0)
+#define __ENDIAN_DEFINED
+#define __BSWAP_DEFINED
+#endif
+
+/* For everything else, use the compiler's predefined endian macros */
+#if !defined (__ENDIAN_DEFINED) && defined (__BYTE_ORDER__) && \
+    defined (__ORDER_LITTLE_ENDIAN__) && defined (__ORDER_BIG_ENDIAN__)
+#define __ENDIAN_DEFINED
+#define _BYTE_ORDER             __BYTE_ORDER__
+#define _LITTLE_ENDIAN          __ORDER_LITTLE_ENDIAN__
+#define _BIG_ENDIAN             __ORDER_BIG_ENDIAN__
+#endif
+
+/* No endian macros found */
+#ifndef __ENDIAN_DEFINED
+#error Could not determine CPU byte order
+#endif
+
+/* POSIX - http://austingroupbugs.net/view.php?id=162 */
+#ifndef BYTE_ORDER
+#define BYTE_ORDER              _BYTE_ORDER
+#endif
+#ifndef LITTLE_ENDIAN
+#define LITTLE_ENDIAN           _LITTLE_ENDIAN
+#endif
+#ifndef BIG_ENDIAN
+#define BIG_ENDIAN              _BIG_ENDIAN
+#endif
+
+/*
+ * Natural to foreign endian helpers defined using bswap
+ *
+ * MSC can't lift byte swap expressions efficiently so we
+ * define host integer swaps using explicit byte swapping.
+ */
+
+/* helps to have these function for symmetry */
+static inline uint8_t le8(uint8_t x) { return x; }
+static inline uint8_t be8(uint8_t x) { return x; }
+
+#if defined(__BSWAP_DEFINED)
+#if _BYTE_ORDER == _BIG_ENDIAN
+static inline uint16_t be16(uint16_t x) { return x; }
+static inline uint32_t be32(uint32_t x) { return x; }
+static inline uint64_t be64(uint64_t x) { return x; }
+static inline uint16_t le16(uint16_t x) { return bswap16(x); }
+static inline uint32_t le32(uint32_t x) { return bswap32(x); }
+static inline uint64_t le64(uint64_t x) { return bswap64(x); }
+#endif
+#if _BYTE_ORDER == _LITTLE_ENDIAN
+static inline uint16_t be16(uint16_t x) { return bswap16(x); }
+static inline uint32_t be32(uint32_t x) { return bswap32(x); }
+static inline uint64_t be64(uint64_t x) { return bswap64(x); }
+static inline uint16_t le16(uint16_t x) { return x; }
+static inline uint32_t le32(uint32_t x) { return x; }
+static inline uint64_t le64(uint64_t x) { return x; }
+#endif
+
+#else
+#define __BSWAP_DEFINED
+
+/*
+ * Natural to foreign endian helpers using type punning
+ *
+ * Recent Clang and GCC lift these expressions to bswap
+ * instructions. This makes baremetal code easier.
+ */
+
+static inline uint16_t be16(uint16_t x)
+{
+    union { uint8_t a[2]; uint16_t b; } y = {
+        .a = { (uint8_t)(x >> 8), (uint8_t)(x) }
+    };
+    return y.b;
+}
+
+static inline uint16_t le16(uint16_t x)
+{
+    union { uint8_t a[2]; uint16_t b; } y = {
+        .a = { (uint8_t)(x), (uint8_t)(x >> 8) }
+    };
+    return y.b;
+}
+
+static inline uint32_t be32(uint32_t x)
+{
+    union { uint8_t a[4]; uint32_t b; } y = {
+        .a = { (uint8_t)(x >> 24), (uint8_t)(x >> 16),
+               (uint8_t)(x >> 8), (uint8_t)(x) }
+    };
+    return y.b;
+}
+
+static inline uint32_t le32(uint32_t x)
+{
+    union { uint8_t a[4]; uint32_t b; } y = {
+        .a = { (uint8_t)(x), (uint8_t)(x >> 8),
+               (uint8_t)(x >> 16), (uint8_t)(x >> 24) }
+    };
+    return y.b;
+}
+
+static inline uint64_t be64(uint64_t x)
+{
+    union { uint8_t a[8]; uint64_t b; } y = {
+        .a = { (uint8_t)(x >> 56), (uint8_t)(x >> 48),
+               (uint8_t)(x >> 40), (uint8_t)(x >> 32),
+               (uint8_t)(x >> 24), (uint8_t)(x >> 16),
+               (uint8_t)(x >> 8), (uint8_t)(x) }
+    };
+    return y.b;
+}
+
+static inline uint64_t le64(uint64_t x)
+{
+    union { uint8_t a[8]; uint64_t b; } y = {
+        .a = { (uint8_t)(x), (uint8_t)(x >> 8),
+               (uint8_t)(x >> 16), (uint8_t)(x >> 24),
+               (uint8_t)(x >> 32), (uint8_t)(x >> 40),
+               (uint8_t)(x >> 48), (uint8_t)(x >> 56) }
+    };
+    return y.b;
+}
+
+/*
+ * Define byte swaps using the natural endian helpers
+ *
+ * This method relies on the compiler lifting byte swaps.
+ */
+#if _BYTE_ORDER == _BIG_ENDIAN
+uint16_t bswap16(uint16_t x) { return le16(x); }
+uint32_t bswap32(uint32_t x) { return le32(x); }
+uint64_t bswap64(uint64_t x) { return le64(x); }
+#endif
+
+#if _BYTE_ORDER == _LITTLE_ENDIAN
+uint16_t bswap16(uint16_t x) { return be16(x); }
+uint32_t bswap32(uint32_t x) { return be32(x); }
+uint64_t bswap64(uint64_t x) { return be64(x); }
+#endif
+#endif
+
+/*
+ * BSD host integer interfaces
+ */
+
+#ifndef __HOSTSWAP_DEFINED
+static inline uint16_t htobe16(uint16_t x) { return be16(x); }
+static inline uint16_t htole16(uint16_t x) { return le16(x); }
+static inline uint16_t be16toh(uint16_t x) { return be16(x); }
+static inline uint16_t le16toh(uint16_t x) { return le16(x); }
+
+static inline uint32_t htobe32(uint32_t x) { return be32(x); }
+static inline uint32_t htole32(uint32_t x) { return le32(x); }
+static inline uint32_t be32toh(uint32_t x) { return be32(x); }
+static inline uint32_t le32toh(uint32_t x) { return le32(x); }
+
+static inline uint64_t htobe64(uint32_t x) { return be64(x); }
+static inline uint64_t htole64(uint32_t x) { return le64(x); }
+static inline uint64_t be64toh(uint32_t x) { return be64(x); }
+static inline uint64_t le64toh(uint32_t x) { return le64(x); }
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xi.cc
+++ b/src/xi.cc
@@ -815,7 +815,7 @@ static void do_nub_server()
  * command line options
  */
 
-void print_help(int argc, char **argv)
+static void print_help(int argc, char **argv)
 {
     fprintf(stderr,
         "Usage: %s [options] [command] <command-parameters>\n"
@@ -843,7 +843,7 @@ void print_help(int argc, char **argv)
         argv[0]);
 }
 
-bool check_param(bool cond, const char *param)
+static bool check_param(bool cond, const char *param)
 {
     if (cond) {
         printf("error: %s requires parameter\n", param);
@@ -851,17 +851,17 @@ bool check_param(bool cond, const char *param)
     return (help_text = cond);
 }
 
-bool match_option(const char *arg, const char *opt, const char *longopt)
+static bool match_option(const char *arg, const char *opt, const char *longopt)
 {
     return strcmp(arg, opt) == 0 || strcmp(arg, longopt) == 0;
 }
 
-bool match_command(const char *arg, const char *cmd)
+static bool match_command(const char *arg, const char *cmd)
 {
     return strcmp(arg, cmd) == 0;
 }
 
-bool parse_nub_client(int argc, char **argv)
+static bool parse_nub_client(int argc, char **argv)
 {
     if (argc < 2) {
         fprintf(stderr, "error: unicode search missing terms\n");
@@ -874,7 +874,7 @@ bool parse_nub_client(int argc, char **argv)
     return (nub_client = true);
 }
 
-bool parse_nub_server(int argc, char **argv)
+static bool parse_nub_server(int argc, char **argv)
 {
     if (argc != 1) {
         fprintf(stderr, "error: invalid nub-server options\n");
@@ -883,7 +883,7 @@ bool parse_nub_server(int argc, char **argv)
     return (nub_server = true);
 }
 
-bool parse_unicode_search(int argc, char **argv)
+static bool parse_unicode_search(int argc, char **argv)
 {
     if (argc < 2) {
         fprintf(stderr, "error: unicode search missing terms\n");
@@ -896,7 +896,7 @@ bool parse_unicode_search(int argc, char **argv)
     return true;
 }
 
-bool parse_options(int argc, char **argv)
+static bool parse_options(int argc, char **argv)
 {
     int i = 1;
     while (i < argc) {

--- a/src/xi.cc
+++ b/src/xi.cc
@@ -35,6 +35,7 @@
 #include "hashmap.h"
 #include "stdendian.h"
 #include "xi_nub.h"
+#include "xi_common.h"
 
 /*
  * xi (aka ξ), a search tool for the Unicode Character Database.
@@ -394,6 +395,9 @@ static vector<unicode_data> do_search_rabin_karp(vector<string> terms)
 
 void do_print_results(vector<unicode_data> data)
 {
+#if defined OS_WINDOWS
+    SetConsoleOutputCP(CP_UTF8);
+#endif
     for (size_t i = 0; i < data.size(); i++) {
         char buf[5];
         utf32_to_utf8(buf, sizeof(buf), data[i].Code);

--- a/src/xi.cc
+++ b/src/xi.cc
@@ -634,6 +634,10 @@ static void do_nub_client()
 {
     xi_nub_ctx *ctx = xi_nub_ctx_get_root_context();
 
+#if defined OS_WINDOWS
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
     if (debug_enabled) {
         printf("\n-- Xi nub-client\n");
         printf("profile_path = \"%s\";\n", xi_nub_ctx_get_profile_path(ctx));

--- a/src/xi.cc
+++ b/src/xi.cc
@@ -681,7 +681,7 @@ static void do_nub_client()
     }
 
     /* start client */
-    const char* args[] = { "xi", "nub-server" };
+    const char* args[] = { "<self>", "nub-server" };
     xi_nub_client *c = xi_nub_client_new(ctx, 2, args);
     const auto t1 = high_resolution_clock::now();
     xi_nub_client_connect(c, 8, my_nub_client_connect_cb);
@@ -851,7 +851,7 @@ static void do_nub_server()
     }
 
     /* start server */
-    const char* args[] = { "xi", "nub-server" };
+    const char* args[] = { "<self>", "nub-server" };
     xi_nub_server *s = xi_nub_server_new(ctx, 2, args);
     xi_nub_server_accept(s, 8, my_nub_server_accept_cb);
 }

--- a/src/xi.cc
+++ b/src/xi.cc
@@ -566,7 +566,7 @@ static void my_nub_client_close_cb(xi_nub_conn *conn, xi_nub_error err)
     mynub_conn *myconn = (mynub_conn *)xi_nub_conn_get_user_data(conn);
 
     if (err) {
-        fprintf(stderr, "error: close(): error_code=%d\n", err);
+        fprintf(stderr, "%s: error: close(): error_code=%d\n", __func__, err);
         return;
     }
 
@@ -581,7 +581,7 @@ static void my_nub_client_read_cb(xi_nub_conn *conn, xi_nub_error err,
     mynub_conn *myconn = (mynub_conn *)xi_nub_conn_get_user_data(conn);
 
     if (err) {
-        fprintf(stderr, "error: read(): error_code=%d\n", err);
+        fprintf(stderr, "%s: error: read(): error_code=%d\n", __func__, err);
         return;
     }
 
@@ -625,7 +625,7 @@ static void my_nub_client_write_cb(xi_nub_conn *conn, xi_nub_error err,
     mynub_conn *myconn = (mynub_conn *)xi_nub_conn_get_user_data(conn);
 
     if (err) {
-        fprintf(stderr, "error: write(): error_code=%d\n", err);
+        fprintf(stderr, "%s: error: write(): error_code=%d\n", __func__, err);
         return;
     }
 
@@ -643,7 +643,7 @@ static void my_nub_client_write_cb(xi_nub_conn *conn, xi_nub_error err,
 static void my_nub_client_connect_cb(xi_nub_conn *conn, xi_nub_error err)
 {
     if (err) {
-        fprintf(stderr, "error: connect(): error_code=%d\n", err);
+        fprintf(stderr, "%s: error: connect(): error_code=%d\n", __func__, err);
         return;
     }
 
@@ -713,7 +713,7 @@ static void my_nub_server_close_cb(xi_nub_conn *conn, xi_nub_error err)
     mynub_conn *myconn = (mynub_conn *)xi_nub_conn_get_user_data(conn);
 
     if (err) {
-        fprintf(stderr, "error: close(): error_code=%d\n", err);
+        fprintf(stderr, "%s: error: close(): error_code=%d\n", __func__, err);
         return;
     }
 
@@ -728,7 +728,7 @@ static void my_nub_server_write_cb(xi_nub_conn *conn, xi_nub_error err,
     mynub_conn *myconn = (mynub_conn *)xi_nub_conn_get_user_data(conn);
 
     if (err) {
-        fprintf(stderr, "error: write(): error_code=%d\n", err);
+        fprintf(stderr, "%s: error: write(): error_code=%d\n", __func__, err);
         return;
     }
 
@@ -746,7 +746,7 @@ static void my_nub_server_read_cb(xi_nub_conn *conn, xi_nub_error err,
     mynub_conn *myconn = (mynub_conn *)xi_nub_conn_get_user_data(conn);
 
     if (err) {
-        fprintf(stderr, "error: read(): error_code=%d\n", err);
+        fprintf(stderr, "%s: error: read(): error_code=%d\n", __func__, err);
         return;
     }
 
@@ -824,7 +824,7 @@ static void my_nub_server_read_cb(xi_nub_conn *conn, xi_nub_error err,
 static void my_nub_server_accept_cb(xi_nub_conn *conn, xi_nub_error err)
 {
     if (err) {
-        fprintf(stderr, "error: accept(): error_code=%d\n", err);
+        fprintf(stderr, "%s: error: accept(): error_code=%d\n", __func__, err);
         return;
     }
 

--- a/src/xi_common.h
+++ b/src/xi_common.h
@@ -1,0 +1,935 @@
+/*
+ * xi_nub - atomically create child process hosting static function.
+ *
+ * Copyright (c) 2020 Michael Clark <michaeljclark@mac.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <cstdio>
+#include <cstddef>
+#include <cerrno>
+
+#include <string>
+
+#ifdef _WIN32
+#define OS_WINDOWS
+#endif
+
+#ifdef __APPLE__
+#define OS_MACOS
+#define OS_POSIX
+#endif
+
+#ifdef __linux__
+#define OS_LINUX
+#define OS_POSIX
+#endif
+
+#if defined OS_WINDOWS
+#include <windows.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#endif
+
+#if defined OS_POSIX
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <sys/un.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <pwd.h>
+#include <semaphore.h>
+#include <time.h>
+#endif
+
+#include "xi_nub.h"
+
+#if !defined MAXPATHLEN && defined MAX_PATH
+#define MAXPATHLEN MAX_PATH
+#endif
+
+#if defined OS_WINDOWS
+#define PATH_SEPARATOR "\\"
+#else
+#define PATH_SEPARATOR "/"
+#endif
+
+/*
+ * nub globals
+ */
+
+static bool debug = false;
+
+
+/*
+ * nub private structures
+ */
+
+enum share_mode {
+    file_create_always,
+    file_create_new,
+    file_open_existing,
+    file_open_always,
+    file_truncate_existing
+};
+
+enum file_perms {
+    file_read = 0x1,
+    file_write = 0x2,
+    file_read_write = 0x3,
+    file_append = 0x4
+};
+
+struct xi_nub_result {
+    xi_nub_error error;
+    intptr_t bytes;
+};
+
+struct xi_nub_file
+{
+    virtual const char* identity() = 0;
+    virtual bool has_error() = 0;
+    virtual int os_error() = 0;
+    virtual xi_nub_error error_code() = 0;
+    virtual ~xi_nub_file() = 0;
+};
+
+inline xi_nub_file::~xi_nub_file() {}
+
+typedef xi_nub_file xi_nub_sock;
+
+/*
+ * platform error mapping
+ */
+
+#if defined OS_WINDOWS
+static xi_nub_error os_error_code(DWORD error) {
+    switch (error) {
+    case 0:                    return xi_nub_success;
+    case ERROR_INVALID_HANDLE: return xi_nub_einval;
+    case ERROR_FILE_NOT_FOUND:
+    case ERROR_PIPE_BUSY:
+    case ERROR_PIPE_NOT_CONNECTED:
+                               return xi_nub_econnrefused;
+    case ERROR_ALREADY_EXISTS: return xi_nub_eexist;
+    case ERROR_ACCESS_DENIED:  return xi_nub_eacces;
+    default:                   return xi_nub_egeneric;
+    }
+}
+#endif
+
+#if defined OS_POSIX
+static xi_nub_error os_error_code(int error) {
+    switch (error) {
+    case 0:             return xi_nub_success;
+    case EINVAL:        return xi_nub_einval;
+    case ECONNREFUSED:  return xi_nub_econnrefused;
+    case EEXIST:        return xi_nub_eexist;
+    case EACCES:        return xi_nub_eacces;
+    default:            return xi_nub_egeneric;
+    }
+}
+#endif
+
+/*
+ * windows file descriptor
+ */
+
+#if defined OS_WINDOWS
+struct xi_nub_win32_file : xi_nub_file
+{
+    HANDLE h;
+    DWORD error;
+    char ident[32];
+
+    xi_nub_win32_file() = default;
+    xi_nub_win32_file(HANDLE h, DWORD error = GetLastError())
+        : h(h), error(error) {}
+
+    virtual const char* identity() {
+        snprintf(ident, sizeof(ident), "handle(%lld)", (long long)h);
+        return ident;
+    }
+
+    virtual bool has_error() { return h == INVALID_HANDLE_VALUE; }
+    virtual int os_error() { return error; }
+    virtual xi_nub_error error_code() { return os_error_code(error); }
+};
+#endif
+
+#if defined OS_WINDOWS
+typedef xi_nub_win32_file xi_nub_win32_sock;
+#endif
+
+
+/*
+ * posix file descriptor
+ */
+
+#if defined OS_POSIX
+struct xi_nub_unix_file : xi_nub_file
+{
+    int fd;
+    int error;
+    char ident[32];
+
+    xi_nub_unix_file() = default;
+    xi_nub_unix_file(int fd, int error = errno)
+        : fd(fd), error(error) {}
+
+    virtual const char* identity() {
+        snprintf(ident, sizeof(ident), "fd(%d)", fd);
+        return ident;
+    }
+
+    virtual bool has_error() { return fd < 0; }
+    virtual int os_error() { return error; }
+    virtual xi_nub_error error_code() { return os_error_code(error); }
+};
+#endif
+
+#if defined OS_POSIX
+typedef xi_nub_unix_file xi_nub_unix_sock;
+#endif
+
+
+/*
+ * utf8 <-> utf16 string conversion
+ */
+
+using string = std::string;
+using wstring = std::wstring;
+
+#if defined OS_WINDOWS
+static string utf16_to_utf8(const wstring w)
+{
+    int l = WideCharToMultiByte(CP_UTF8, 0, &w[0], (int)w.size(), NULL, 0, NULL, NULL);
+    string s(l, 0);
+    WideCharToMultiByte(CP_UTF8, 0, &w[0], (int)w.size(), &s[0], l, NULL, NULL);
+    return s;
+}
+#endif
+
+#if defined OS_WINDOWS
+static wstring utf8_to_utf16(const string s)
+{
+    int l = MultiByteToWideChar(CP_UTF8, 0, &s[0], (int)s.size(), NULL, 0);
+    wstring w(l, 0);
+    MultiByteToWideChar(CP_UTF8, 0, &s[0], (int)s.size(), &w[0], l);
+    return w;
+}
+#endif
+
+
+/*
+ * Windows time
+ */
+
+#if defined OS_WINDOWS
+static uint64_t _clock_time_ns()
+{
+    static LARGE_INTEGER f;
+
+    LARGE_INTEGER t;
+    if (!f.QuadPart) {
+        QueryPerformanceFrequency(&f);
+    }
+    QueryPerformanceCounter(&t);
+
+    return t.QuadPart * 1000000000ull / f.QuadPart;
+}
+#endif
+
+
+/*
+ * POSIX time
+ */
+
+#if defined OS_POSIX
+static uint64_t _clock_time_ns()
+{
+    struct timespec res;
+    clock_gettime(CLOCK_REALTIME, &res);
+    return (uint64_t)res.tv_nsec + (uint64_t)res.tv_sec * 1000000000ll;
+}
+#endif
+
+
+/*
+ * windows named semaphore
+ */
+
+#if defined OS_WINDOWS
+struct xi_nub_win32_semaphore : xi_nub_file
+{
+    HANDLE h;
+    DWORD error;
+    char ident[32];
+
+    xi_nub_win32_semaphore() = default;
+    xi_nub_win32_semaphore(HANDLE h, DWORD error = GetLastError())
+        : h(h), error(error) {}
+
+    virtual const char* identity() {
+        snprintf(ident, sizeof(ident), "handle(%lld)", (long long)h);
+        return ident;
+    }
+
+    virtual bool has_error() { return h == INVALID_HANDLE_VALUE; }
+    virtual int os_error() { return error; }
+    virtual xi_nub_error error_code() { return os_error_code(error); }
+};
+#endif
+
+#if defined OS_WINDOWS
+typedef xi_nub_win32_semaphore xi_nub_platform_semaphore;
+#endif
+
+#if defined OS_WINDOWS
+static xi_nub_win32_semaphore _semaphore_create(const char *name)
+{
+    HANDLE h = CreateSemaphoreW(NULL, /* initial */0, /* maximal */ 1,
+                                utf8_to_utf16(name).c_str());
+    return xi_nub_win32_semaphore(h, GetLastError());
+}
+#endif
+
+#if defined OS_WINDOWS
+static xi_nub_win32_semaphore _semaphore_open(const char *name)
+{
+    HANDLE h = OpenSemaphoreW(SEMAPHORE_MODIFY_STATE, 0,
+                              utf8_to_utf16(name).c_str());
+    return xi_nub_win32_semaphore(h, GetLastError());
+}
+#endif
+
+#if defined OS_WINDOWS
+static bool _semaphore_close(xi_nub_win32_semaphore *s)
+{
+    return CloseHandle(s->h);
+}
+#endif
+
+#if defined OS_WINDOWS
+static bool _semaphore_unlink(const char *name)
+{
+    return true; /* windows reference counts semaphores */
+}
+#endif
+
+#if defined OS_WINDOWS
+static bool _semaphore_wait(xi_nub_win32_semaphore *s, int milliseonds)
+{
+    /* error cases: WAIT_TIMEOUT, WAIT_FAILED, WAIT_ABANDONED */
+    DWORD ret = WaitForSingleObject(s->h, milliseonds);
+    return (ret == WAIT_OBJECT_0);
+}
+#endif
+
+#if defined OS_WINDOWS
+static bool _semaphore_signal(xi_nub_win32_semaphore *s)
+{
+    LONG prev = 0;
+    bool ret = ReleaseSemaphore(s->h, 1, &prev);
+    return (ret && prev == 0);
+}
+#endif
+
+
+/*
+ * posix named semaphore
+ */
+
+#if defined OS_POSIX
+struct xi_nub_unix_semaphore : xi_nub_file
+{
+    //int fd;
+    sem_t *sem;
+    int error;
+    char ident[32];
+
+    xi_nub_unix_semaphore() = default;
+    xi_nub_unix_semaphore(sem_t *sem, int error = errno)
+        : sem(sem), error(error) {}
+
+    virtual const char* identity() {
+        snprintf(ident, sizeof(ident), "sem(%p)", sem);
+        return ident;
+    }
+
+    virtual bool has_error() { return sem == SEM_FAILED; }
+    virtual int os_error() { return error; }
+    virtual xi_nub_error error_code() { return os_error_code(error); }
+};
+#endif
+
+#if defined OS_POSIX
+typedef xi_nub_unix_semaphore xi_nub_platform_semaphore;
+#endif
+
+#if defined OS_POSIX
+static xi_nub_unix_semaphore _semaphore_create(const char *name)
+{
+    sem_t *sem = sem_open(name, O_CREAT | O_EXCL, 0644, 0);
+    return xi_nub_unix_semaphore(sem, errno);
+}
+#endif
+
+#if defined OS_POSIX
+static xi_nub_unix_semaphore _semaphore_open(const char *name)
+{
+    sem_t *sem = sem_open(name, 0);
+    return xi_nub_unix_semaphore(sem, errno);
+}
+#endif
+
+#if defined OS_POSIX
+static bool _semaphore_close(xi_nub_unix_semaphore *s)
+{
+    int ret = sem_close(s->sem);
+    return (ret == 0);
+}
+#endif
+
+#if defined OS_POSIX
+static bool _semaphore_unlink(const char *name)
+{
+    int ret = sem_unlink(name);
+    return (ret == 0);
+}
+#endif
+
+#if defined OS_POSIX
+static bool _semaphore_wait(xi_nub_unix_semaphore *s, int millis)
+{
+    struct timespec ta, t1, t2 = { millis / 1000, (millis % 1000) * 1000000 };
+    clock_gettime(CLOCK_REALTIME, &t1);
+    ta.tv_sec = t1.tv_sec+t2.tv_sec + (t1.tv_nsec+t2.tv_nsec) / 1000000000ul;
+    ta.tv_nsec = (t1.tv_nsec+t2.tv_nsec) % 1000000000ul;
+    int ret = sem_timedwait(s->sem, &ta);
+    return !(ret < 0 && errno == ETIMEDOUT);
+}
+#endif
+
+#if defined OS_POSIX
+static bool _semaphore_signal(xi_nub_unix_semaphore *s)
+{
+    int ret = sem_post(s->sem);
+    return (ret == 0);
+}
+#endif
+
+/*
+ * filesystem helpers
+ */
+
+#if defined OS_WINDOWS
+static bool _directory_exists(const char *path)
+{
+    DWORD dwAttrib = GetFileAttributesW(utf8_to_utf16(path).c_str());
+    return (dwAttrib != INVALID_FILE_ATTRIBUTES &&
+           (dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
+}
+#endif
+
+#if defined OS_WINDOWS
+static bool _make_directory(const char *path)
+{
+    return CreateDirectoryW(utf8_to_utf16(path).c_str(), NULL) != 0;
+}
+#endif
+
+#if defined OS_POSIX
+static bool _directory_exists(const char *path)
+{
+    struct stat sb;
+    int ret = stat(path, &sb);
+    return ret == 0 && ((sb.st_mode & S_IFMT) == S_IFDIR);
+}
+#endif
+
+#if defined OS_POSIX
+static bool _make_directory(const char *path)
+{
+    return mkdir(path, 0777) == 0;
+}
+#endif
+
+#if defined OS_WINDOWS
+static std::string windows_getenv(const char *name)
+{
+    size_t len;
+    std::string s;
+    getenv_s(&len, NULL, 0, name);
+    s.resize(len);
+    getenv_s(&len, s.data(), len, name);
+    return s;
+}
+#endif
+
+
+/*
+ * windows memory mapped files
+ */
+
+#if defined OS_WINDOWS
+struct xi_nub_mm
+{
+    HANDLE h;
+    HANDLE hmap;
+    void *map;
+};
+#endif
+
+#if defined OS_WINDOWS
+static xi_nub_mm _map_file(const char *fname, share_mode smode, int access,
+    size_t length)
+{
+    DWORD omode = 0;
+    switch (smode) {
+    case file_create_always:     omode = CREATE_ALWAYS;     break;
+    case file_create_new:        omode = CREATE_NEW;        break;
+    case file_open_existing:     omode = OPEN_EXISTING;     break;
+    case file_open_always:       omode = OPEN_ALWAYS;       break;
+    case file_truncate_existing: omode = TRUNCATE_EXISTING; break;
+    }
+    DWORD oaccess = 0;
+    if (access & file_read) oaccess |= FILE_GENERIC_READ;
+    if (access & file_write) oaccess |= FILE_GENERIC_WRITE;
+    if (access & file_append) oaccess |= FILE_APPEND_DATA;
+    HANDLE h = CreateFile(fname, oaccess, 0, NULL, omode,
+                       FILE_FLAG_RANDOM_ACCESS, NULL);
+    if (h == INVALID_HANDLE_VALUE)
+    {
+        fprintf(stderr, "error: CreateFile(\"%s\"): ret=0x%08x\n",
+            fname, GetLastError());
+        return xi_nub_mm { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, NULL };
+    }
+
+    if (length) {
+        SetFileValidData(h, length);
+        if (!SetEndOfFile(h)) {
+            fprintf(stderr, "error: SetEndOfFile(): ret=0x%08x\n", GetLastError());
+            CloseHandle(h);
+            return xi_nub_mm { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, NULL };
+        }
+    } else {
+        _BY_HANDLE_FILE_INFORMATION file_info;
+        GetFileInformationByHandle(h, &file_info);
+        length = (size_t)file_info.nFileSizeLow |
+            ((size_t)file_info.nFileSizeHigh << 32);
+    }
+
+    DWORD mprot = SEC_COMMIT;
+    if ((access & file_read_write) == file_read_write) mprot |= PAGE_READWRITE;
+    else if (access & file_read ) mprot |= PAGE_READONLY;
+    HANDLE hmap = CreateFileMapping(h, NULL, mprot, 0, 0, 0);
+    if (hmap == NULL) {
+        fprintf(stderr, "error: CreateFileMapping(): ret=0x%08x\n",
+            GetLastError());
+        CloseHandle(h);
+        return xi_nub_mm { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, NULL };
+    }
+
+    DWORD maccess = 0;
+    if (access & file_read) maccess |= FILE_MAP_WRITE;
+    if (access & file_write) maccess |= FILE_MAP_READ;
+    HANDLE map = MapViewOfFile(hmap, maccess, 0, 0, 0);
+    if (map == NULL) {
+        fprintf(stderr, "error: MapViewOfFile(): ret=0x%08x\n",
+            GetLastError());
+        CloseHandle(hmap);
+        CloseHandle(h);
+        return xi_nub_mm { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, NULL };
+    }
+
+    return xi_nub_mm { h, hmap, map };
+}
+#endif
+
+
+/*
+ * posix memory mapped files
+ */
+
+#if defined OS_POSIX
+struct xi_nub_mm
+{
+    int fd;
+    void *map;
+};
+#endif
+
+#if defined OS_POSIX
+static xi_nub_mm _map_file(const char *fname, share_mode smode, int access,
+    size_t length)
+{
+    int oflags = 0;
+    switch (smode) {
+    case file_create_always:     oflags = O_CREAT | O_TRUNC; break;
+    case file_create_new:        oflags = O_CREAT | O_EXCL;  break;
+    case file_open_existing:     oflags = 0;                 break;
+    case file_open_always:       oflags = O_CREAT;           break;
+    case file_truncate_existing: oflags = O_TRUNC;           break;
+    }
+    if ((access & file_read_write) == file_read_write) oflags |= O_RDWR;
+    else if (access & file_read) oflags |= O_RDONLY;
+    else if (access & file_write) oflags |= O_WRONLY;
+
+    int fd = open(fname, oflags, 0644);
+    if (fd < 0) {
+        fprintf(stderr, "error: open(\"%s\"): %s\n",fname, strerror(errno));
+            return xi_nub_mm{ -1, NULL };
+    }
+
+    if (length) {
+        int ret = ftruncate(fd, length);
+        if (ret < 0) {
+            fprintf(stderr, "error: ftruncate(): %s\n", strerror(errno));
+            close(fd);
+            return xi_nub_mm{ -1, NULL };
+        }
+    } else {
+        struct stat s;
+        if (fstat(fd, &s) < 0) {
+            fprintf(stderr, "error: fstat(): %s\n", strerror(errno));
+            close(fd);
+            return xi_nub_mm{ -1, NULL };
+        }
+        length = s.st_size;
+    }
+
+    off_t offset = 0;
+    void *map = mmap(NULL, length, PROT_READ|PROT_WRITE, MAP_SHARED, fd, offset);
+    if (map == NULL) {
+        fprintf(stderr, "error: mmap(): %s\n", strerror(errno));
+        close(fd);
+            return xi_nub_mm{ -1, NULL };
+    }
+
+    return xi_nub_mm{ fd, map };
+}
+#endif
+
+
+/*
+ * windows file io
+ */
+
+#if defined OS_WINDOWS
+static xi_nub_win32_file _open_file(const char *fname, share_mode smode, int access)
+{
+    DWORD omode = 0;
+    switch (smode) {
+    case file_create_always:     omode = CREATE_ALWAYS;     break;
+    case file_create_new:        omode = CREATE_NEW;        break;
+    case file_open_existing:     omode = OPEN_EXISTING;     break;
+    case file_open_always:       omode = OPEN_ALWAYS;       break;
+    case file_truncate_existing: omode = TRUNCATE_EXISTING; break;
+    }
+    DWORD oaccess = 0;
+    if (access & file_read) oaccess |= FILE_GENERIC_READ;
+    if (access & file_write) oaccess |= FILE_GENERIC_WRITE;
+    if (access & file_append) oaccess |= FILE_APPEND_DATA;
+    HANDLE h = CreateFile(fname, oaccess, 0, NULL, omode,
+                       FILE_FLAG_RANDOM_ACCESS, NULL);
+    return xi_nub_win32_file(h, GetLastError());
+}
+#endif
+
+#if defined OS_WINDOWS
+static xi_nub_result _read(xi_nub_win32_file *file, void *buf, size_t len)
+{
+    DWORD nbytes;
+    BOOL ret = ReadFile(file->h, buf, (DWORD)len, &nbytes, NULL);
+    return xi_nub_result{ os_error_code(GetLastError()), ret ? nbytes : -1 };
+}
+
+static xi_nub_result _write(xi_nub_win32_file *file, void *buf, size_t len)
+{
+    DWORD nbytes;
+    BOOL ret = WriteFile(file->h, buf, (DWORD)len, &nbytes, NULL);
+    return xi_nub_result{ os_error_code(GetLastError()), ret ? nbytes : -1 };
+}
+
+static xi_nub_result _disconnect(xi_nub_win32_file *file)
+{
+    BOOL ret = DisconnectNamedPipe(file->h);
+    return xi_nub_result{ os_error_code(GetLastError()), ret ? 0 : -1 };
+}
+
+static xi_nub_result _close(xi_nub_win32_file *file)
+{
+    BOOL ret = CloseHandle(file->h);
+    return xi_nub_result{ os_error_code(GetLastError()), ret ? 0 : -1 };
+}
+#endif
+
+
+/*
+ * posix file io
+ */
+
+#if defined OS_POSIX
+static xi_nub_unix_file _open_file(const char *fname, share_mode smode, int access)
+{
+    int oflags = 0;
+    switch (smode) {
+    case file_create_always:     oflags = O_CREAT | O_TRUNC; break;
+    case file_create_new:        oflags = O_CREAT | O_EXCL;  break;
+    case file_open_existing:     oflags = 0;                 break;
+    case file_open_always:       oflags = O_CREAT;           break;
+    case file_truncate_existing: oflags = O_TRUNC;           break;
+    }
+    if ((access & file_read_write) == file_read_write) oflags |= O_RDWR;
+    else if (access & file_read) oflags |= O_RDONLY;
+    else if (access & file_write) oflags |= O_WRONLY;
+    if (access & file_append) oflags |= O_APPEND|O_WRONLY;
+    int fd = open(fname, oflags, 0644);
+    return xi_nub_unix_file(fd, errno);
+}
+#endif
+
+#if defined OS_POSIX
+static xi_nub_result _read(xi_nub_unix_file *file, void *buf, size_t len)
+{
+    intptr_t ret = read(file->fd, buf, len);
+    return xi_nub_result{ os_error_code(errno), ret };
+}
+
+static xi_nub_result _write(xi_nub_unix_file *file, void *buf, size_t len)
+{
+    intptr_t ret = write(file->fd, buf, len);
+    return xi_nub_result{ os_error_code(errno), ret };
+}
+
+static xi_nub_result _disconnect(xi_nub_unix_file *file)
+{
+    intptr_t ret = close(file->fd);
+    return xi_nub_result{ os_error_code(errno), ret };
+}
+
+static xi_nub_result _close(xi_nub_unix_file *file)
+{
+    intptr_t ret = close(file->fd);
+    return xi_nub_result{ os_error_code(errno), ret };
+}
+#endif
+
+
+/*
+ * file position
+ */
+
+#if defined OS_WINDOWS
+static xi_nub_result _get_file_offset(xi_nub_win32_file *file)
+{
+    DWORD ret = SetFilePointer(file->h, 0, 0, FILE_CURRENT);
+    return xi_nub_result{ os_error_code(GetLastError()),
+        ret != INVALID_SET_FILE_POINTER ? ret : -1 };
+}
+#endif
+
+#if defined OS_POSIX
+static xi_nub_result _get_file_offset(xi_nub_unix_file *file)
+{
+    off_t ret = lseek(file->fd, 0, SEEK_CUR);
+    return xi_nub_result{ os_error_code(errno), ret };
+}
+#endif
+
+
+/*
+ * process management
+ */
+
+#if defined OS_WINDOWS
+typedef int32_t xi_pid_t;
+static xi_pid_t _get_processs_id()
+{
+    return (xi_pid_t)GetCurrentProcessId();
+}
+#endif
+
+#if defined OS_POSIX
+typedef int32_t xi_pid_t;
+static xi_pid_t _get_processs_id()
+{
+    return (xi_pid_t)getpid();
+}
+#endif
+
+
+/*
+ * windows sockets
+ */
+
+#if defined OS_WINDOWS
+typedef xi_nub_win32_sock xi_nub_platform_sock;
+#endif
+
+#if defined OS_WINDOWS
+static xi_nub_platform_sock listen_socket_create()
+{
+    DWORD open_mode = PIPE_ACCESS_DUPLEX;
+    DWORD pipe_mode = PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT;
+    LPWSTR pipe_name = L"\\\\.\\pipe\\Xi";
+    DWORD buf_size = 65536;
+
+    HANDLE h = CreateNamedPipeW(pipe_name, open_mode, pipe_mode,
+                                    PIPE_UNLIMITED_INSTANCES,
+                                    buf_size, buf_size,
+                                    NMPWAIT_USE_DEFAULT_WAIT, NULL);
+    if (h == INVALID_HANDLE_VALUE)
+    {
+        fprintf(stderr, "error: CreateNamedPipe(): ret=0x%08x\n", GetLastError());
+        return xi_nub_platform_sock(INVALID_HANDLE_VALUE, GetLastError());
+    }
+
+    return xi_nub_platform_sock(h, GetLastError());
+}
+#endif
+
+#if defined OS_WINDOWS
+static xi_nub_platform_sock listen_socket_accept(xi_nub_platform_sock l)
+{
+    /*
+     * we only connect one socket and then must create a new pipe
+     * to accept subsequent connections
+     */
+    int ret = ConnectNamedPipe(l.h, NULL);
+    if (ret || (GetLastError() == ERROR_PIPE_CONNECTED)) {
+        return xi_nub_platform_sock(l.h, GetLastError());
+    } else {
+        return xi_nub_platform_sock(INVALID_HANDLE_VALUE, GetLastError());
+    }
+}
+#endif
+
+#if defined OS_WINDOWS
+static xi_nub_platform_sock client_socket_connect()
+{
+    LPWSTR pipe_name = L"\\\\.\\pipe\\Xi";
+
+    DWORD buf_size = 65536;
+
+    HANDLE h = CreateFileW(pipe_name, GENERIC_READ | GENERIC_WRITE,
+                               0, NULL, OPEN_EXISTING, 0, NULL);
+    if (h == INVALID_HANDLE_VALUE)
+    {
+        fprintf(stderr, "error: CreateFile(): ret=0x%08x\n", GetLastError());
+        return xi_nub_platform_sock(INVALID_HANDLE_VALUE, GetLastError());
+    }
+
+    return xi_nub_platform_sock(h, GetLastError());
+}
+#endif
+
+
+/*
+ * posix sockets
+ */
+
+#if defined OS_POSIX
+typedef xi_nub_unix_sock xi_nub_platform_sock;
+#endif
+
+#if defined OS_POSIX
+static xi_nub_platform_sock listen_socket_create()
+{
+    const char *pipe_path = "Xi";
+    sockaddr_un saddr;
+
+    memset(&saddr, 0, sizeof(saddr));
+    saddr.sun_family = AF_UNIX;
+
+    size_t saddr_len = offsetof(sockaddr_un,sun_path) + strlen(pipe_path) + 1;
+    strncpy(saddr.sun_path + 1, pipe_path, strlen(pipe_path));
+
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        fprintf(stderr, "error: socket(): %s\n", strerror(errno));
+        return xi_nub_platform_sock(-1, errno);
+    }
+
+    int enable = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0) {
+        fprintf(stderr, "error: setsockopt(): %s\n", strerror(errno));
+        close(fd);
+        return xi_nub_platform_sock(-1, errno);
+    }
+
+    if (bind(fd, (sockaddr*)(&saddr), saddr_len) < 0) {
+        fprintf(stderr, "error: bind(): %s\n", strerror(errno));
+        close(fd);
+        return xi_nub_platform_sock(-1, errno);
+    }
+
+    if (listen(fd, 256) < 0) {
+        fprintf(stderr, "error: listen(): %s\n", strerror(errno));
+        close(fd);
+        return xi_nub_platform_sock(-1, errno);
+    }
+
+    return xi_nub_platform_sock(fd, 0);
+}
+#endif
+
+#if defined OS_POSIX
+static xi_nub_platform_sock listen_socket_accept(xi_nub_platform_sock l)
+{
+    struct sockaddr saddr;
+    socklen_t saddrlen = sizeof(saddr);
+
+    int fd = accept(l.fd, &saddr, &saddrlen);
+    if (fd < 0) {
+        fprintf(stderr, "error: accept failed: %s\n", strerror(errno));
+        return xi_nub_platform_sock(-1, errno);
+    }
+
+    return xi_nub_platform_sock(fd, 0);
+}
+#endif
+
+#if defined OS_POSIX
+static xi_nub_platform_sock client_socket_connect()
+{
+    const char *pipe_path = "Xi";
+    sockaddr_un saddr;
+
+    memset(&saddr, 0, sizeof(saddr));
+    saddr.sun_family = AF_UNIX;
+
+    size_t saddr_len = offsetof(sockaddr_un,sun_path) + strlen(pipe_path) + 1;
+    strncpy(saddr.sun_path + 1, pipe_path, strlen(pipe_path));
+
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        fprintf(stderr, "error: socket(): %s\n", strerror(errno));
+        return xi_nub_platform_sock(-1, errno);
+    }
+
+    if (connect(fd, (sockaddr*)(&saddr), saddr_len) < 0) {
+        fprintf(stderr, "error: bind(): %s\n", strerror(errno));
+        close(fd);
+        return xi_nub_platform_sock(-1, errno);
+    }
+    return xi_nub_platform_sock(fd, 0);
+}
+#endif
+

--- a/src/xi_common.h
+++ b/src/xi_common.h
@@ -350,6 +350,14 @@ static bool _semaphore_signal(xi_nub_win32_semaphore *s)
 }
 #endif
 
+#if defined OS_WINDOWS
+static bool _thread_sleep(int millis)
+{
+    Sleep(millis);
+    return true;
+}
+#endif
+
 
 /*
  * posix named semaphore
@@ -431,6 +439,15 @@ static bool _semaphore_signal(xi_nub_unix_semaphore *s)
 {
     int ret = sem_post(s->sem);
     return (ret == 0);
+}
+#endif
+
+#if defined OS_POSIX
+static bool _thread_sleep(int millis)
+{
+    struct timespec ta = { millis / 1000, (millis % 1000) * 1000000 };
+    int ret = nanosleep(&ta, NULL);
+    return ret == 0;
 }
 #endif
 

--- a/src/xi_common.h
+++ b/src/xi_common.h
@@ -512,8 +512,8 @@ static xi_nub_mm _map_file(const char *fname, share_mode smode, int access,
     if (access & file_read) oaccess |= FILE_GENERIC_READ;
     if (access & file_write) oaccess |= FILE_GENERIC_WRITE;
     if (access & file_append) oaccess |= FILE_APPEND_DATA;
-    HANDLE h = CreateFile(fname, oaccess, 0, NULL, omode,
-                       FILE_FLAG_RANDOM_ACCESS, NULL);
+    HANDLE h = CreateFileW(utf8_to_utf16(fname).c_str(), oaccess, 0, NULL,
+                           omode, FILE_FLAG_RANDOM_ACCESS, NULL);
     if (h == INVALID_HANDLE_VALUE)
     {
         fprintf(stderr, "error: CreateFile(\"%s\"): ret=0x%08x\n",
@@ -646,8 +646,8 @@ static xi_nub_win32_file _open_file(const char *fname, share_mode smode, int acc
     if (access & file_read) oaccess |= FILE_GENERIC_READ;
     if (access & file_write) oaccess |= FILE_GENERIC_WRITE;
     if (access & file_append) oaccess |= FILE_APPEND_DATA;
-    HANDLE h = CreateFile(fname, oaccess, 0, NULL, omode,
-                       FILE_FLAG_RANDOM_ACCESS, NULL);
+    HANDLE h = CreateFileW(utf8_to_utf16(fname).c_str(), oaccess, 0, NULL,
+                       omode, FILE_FLAG_RANDOM_ACCESS, NULL);
     return xi_nub_win32_file(h, GetLastError());
 }
 #endif

--- a/src/xi_nub.cc
+++ b/src/xi_nub.cc
@@ -1,0 +1,854 @@
+/*
+ * xi_nub - atomically create child process hosting static function.
+ *
+ * Copyright (c) 2020 Michael Clark <michaeljclark@mac.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cerrno>
+
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#define OS_WINDOWS
+#endif
+
+#ifdef __APPLE__
+#define OS_MACOS
+#define OS_POSIX
+#endif
+
+#ifdef __linux__
+#define OS_LINUX
+#define OS_POSIX
+#endif
+
+#if defined OS_WINDOWS
+#include <windows.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#endif
+
+#if defined OS_POSIX
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <sys/un.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <pwd.h>
+#endif
+
+#include "xi_nub.h"
+
+#if !defined MAXPATHLEN && defined MAX_PATH
+#define MAXPATHLEN MAX_PATH
+#endif
+
+
+/*
+ * nub globals
+ */
+
+static bool debug = false;
+
+#if defined OS_WINDOWS
+const char *profile_template = "%s\\Xi";
+#elif defined OS_MACOS
+const char *profile_template = "%s/Library/Application Support/Xi";
+#elif defined OS_LINUX
+const char *profile_template =  "%s/.config/Xi";
+#endif
+
+
+/*
+ * nub private structures
+ */
+
+enum share_mode {
+    file_create_always,
+    file_create_new,
+    file_open_existing,
+    file_open_always,
+    file_truncate_existing
+};
+
+struct xi_nub_result {
+    xi_nub_error error;
+    intptr_t bytes;
+};
+
+struct xi_nub_file
+{
+    virtual const char* identity() = 0;
+    virtual bool has_error() = 0;
+    virtual int os_error() = 0;
+    virtual xi_nub_error error_code() = 0;
+    virtual ~xi_nub_file() = 0;
+};
+
+xi_nub_file::~xi_nub_file() {}
+
+typedef xi_nub_file xi_nub_sock;
+
+struct xi_nub_ctx
+{
+    std::string user_name;
+    std::string home_path;
+    std::string profile_path;
+    void *user_data;
+};
+
+struct xi_nub_server
+{
+    xi_nub_ctx *ctx;
+};
+
+struct xi_nub_client
+{
+    xi_nub_ctx *ctx;
+};
+
+struct xi_nub_conn
+{
+    xi_nub_ctx *ctx;
+    xi_nub_server *server;
+    xi_nub_client *client;
+    xi_nub_sock *sock;
+    void *user_data;
+};
+
+
+/*
+ * platform error mapping
+ */
+
+#if defined OS_WINDOWS
+static xi_nub_error os_error_code(DWORD error) {
+    switch (error) {
+    case 0:                    return xi_nub_success;
+    case ERROR_INVALID_HANDLE: return xi_nub_einval;
+    case ERROR_FILE_NOT_FOUND:
+    case ERROR_PIPE_BUSY:
+    case ERROR_PIPE_NOT_CONNECTED:
+                               return xi_nub_econnrefused;
+    default:                   return xi_nub_egeneric;
+    }
+}
+#endif
+
+#if defined OS_POSIX
+static xi_nub_error os_error_code(int error) {
+    switch (error) {
+    case 0:             return xi_nub_success;
+    case EINVAL:        return xi_nub_einval;
+    case ECONNREFUSED:  return xi_nub_econnrefused;
+    default:            return xi_nub_egeneric;
+    }
+}
+#endif
+
+
+/*
+ * windows file descriptor
+ */
+
+#if defined OS_WINDOWS
+struct xi_nub_win32_file : xi_nub_file
+{
+    HANDLE h;
+    DWORD error;
+    char ident[32];
+
+    xi_nub_win32_file(HANDLE h, DWORD error = GetLastError())
+        : h(h), error(error) {}
+
+    virtual const char* identity() {
+        snprintf(ident, sizeof(ident), "handle(%lld)", (long long)h);
+        return ident;
+    }
+
+    virtual bool has_error() { return h == INVALID_HANDLE_VALUE; }
+    virtual int os_error() { return error; }
+    virtual xi_nub_error error_code() { return os_error_code(error); }
+};
+#endif
+
+#if defined OS_WINDOWS
+typedef xi_nub_win32_file xi_nub_win32_sock;
+#endif
+
+
+/*
+ * posix file descriptor
+ */
+
+#if defined OS_POSIX
+struct xi_nub_unix_file : xi_nub_file
+{
+    int fd;
+    int error;
+    char ident[32];
+
+    xi_nub_unix_file(int fd, int error = errno)
+        : fd(fd), error(error) {}
+
+    virtual const char* identity() {
+        snprintf(ident, sizeof(ident), "fd(%d)", fd);
+        return ident;
+    }
+
+    virtual bool has_error() { return fd < 0;}
+    virtual int os_error() { return error; }
+    virtual xi_nub_error error_code() { return os_error_code(error); }
+};
+#endif
+
+#if defined OS_POSIX
+typedef xi_nub_unix_file xi_nub_unix_sock;
+#endif
+
+
+/*
+ * utf8 <-> utf16 string conversion
+ */
+
+using string = std::string;
+using wstring = std::wstring;
+
+#if defined OS_WINDOWS
+static string utf16_to_utf8(const wstring w)
+{
+    int l = WideCharToMultiByte(CP_UTF8, 0, &w[0], (int)w.size(), NULL, 0, NULL, NULL);
+    string s(l, 0);
+    WideCharToMultiByte(CP_UTF8, 0, &w[0], (int)w.size(), &s[0], l, NULL, NULL);
+    return s;
+}
+#endif
+
+#if defined OS_WINDOWS
+static wstring utf8_to_utf16(const string s)
+{
+    int l = MultiByteToWideChar(CP_UTF8, 0, &s[0], (int)s.size(), NULL, 0);
+    wstring w(l, 0);
+    MultiByteToWideChar(CP_UTF8, 0, &s[0], (int)s.size(), &w[0], l);
+    return w;
+}
+#endif
+
+
+/*
+ * filesystem helpers
+ */
+
+#if defined OS_WINDOWS
+static bool directory_exists(const char *path)
+{
+    DWORD dwAttrib = GetFileAttributesW(utf8_to_utf16(path).c_str());
+    return (dwAttrib != INVALID_FILE_ATTRIBUTES &&
+           (dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
+}
+#endif
+
+#if defined OS_WINDOWS
+static bool make_directory(const char *path)
+{
+    return CreateDirectoryW(utf8_to_utf16(path).c_str(), NULL) != 0;
+}
+#endif
+
+#if defined OS_POSIX
+static bool directory_exists(const char *path)
+{
+    struct stat sb;
+    int ret = stat(path, &sb);
+    return ret == 0 && ((sb.st_mode & S_IFMT) == S_IFDIR);
+}
+#endif
+
+#if defined OS_POSIX
+static bool make_directory(const char *path)
+{
+    return mkdir(path, 0777) == 0;
+}
+#endif
+
+#if defined OS_WINDOWS
+static std::string windows_getenv(const char *name)
+{
+    size_t len;
+    std::string s;
+    getenv_s(&len, NULL, 0, name);
+    s.resize(len);
+    getenv_s(&len, s.data(), len, name);
+    return s;
+}
+#endif
+
+
+/*
+ * profile directory
+ */
+
+#if defined OS_WINDOWS
+static void xi_nub_find_dirs(xi_nub_ctx *ctx)
+{
+    char profile_path_tmp[MAXPATHLEN];
+    ctx->user_name = windows_getenv("USERNAME");
+    ctx->home_path = windows_getenv("HOMEPATH");
+    std::string appdata =  windows_getenv("APPDATA");
+    snprintf(profile_path_tmp, MAX_PATH, profile_template, appdata.c_str());
+    ctx->profile_path = profile_path_tmp;
+}
+#endif
+
+#if defined OS_POSIX
+static void xi_nub_find_dirs(xi_nub_ctx *ctx)
+{
+    char profile_path_tmp[MAXPATHLEN];
+    struct passwd *p = getpwuid(getuid());
+    ctx->user_name = p->pw_name;
+    ctx->home_path = p->pw_dir;
+    snprintf(profile_path_tmp, MAXPATHLEN, profile_template, ctx->home_path.c_str());
+    ctx->profile_path = profile_path_tmp;
+}
+#endif
+
+
+/*
+ * windows memory mapped files
+ */
+
+#if defined OS_WINDOWS
+struct xi_nub_mm
+{
+    HANDLE h;
+    HANDLE hmap;
+    void *map;
+};
+#endif
+
+#if defined OS_WINDOWS
+static bool _map_file(xi_nub_mm *mm, const char *fname,
+    share_mode smode, size_t length)
+{
+    DWORD omode = 0;
+    switch (smode) {
+    case file_create_always:     omode = CREATE_ALWAYS;     break;
+    case file_create_new:        omode = CREATE_NEW;        break;
+    case file_open_existing:     omode = OPEN_EXISTING;     break;
+    case file_open_always:       omode = OPEN_ALWAYS;       break;
+    case file_truncate_existing: omode = TRUNCATE_EXISTING; break;
+    }
+    mm->h = CreateFile(fname, GENERIC_READ | GENERIC_WRITE, 0, NULL, omode,
+                       FILE_FLAG_RANDOM_ACCESS, NULL);
+    if (mm->h == INVALID_HANDLE_VALUE)
+    {
+        fprintf(stderr, "error: CreateFile(\"%s\"): ret=0x%08x\n",
+            fname, GetLastError());
+        return false;
+    }
+
+    /* truncate file */
+    if (length) {
+        SetFileValidData(mm->h, length);
+        if (!SetEndOfFile(mm->h)) {
+            fprintf(stderr, "error: SetEndOfFile(): ret=0x%08x\n",
+                GetLastError());
+            CloseHandle(mm->h);
+            return false;
+        }
+    } else {
+        _BY_HANDLE_FILE_INFORMATION file_info;
+        GetFileInformationByHandle(mm->h, &file_info);
+        length = (size_t)file_info.nFileSizeLow |
+            ((size_t)file_info.nFileSizeHigh << 32);
+    }
+
+    /* memory map file */
+    mm->hmap = CreateFileMapping(mm->h, NULL, PAGE_READWRITE |SEC_RESERVE,
+                                 0, 0, 0);
+    if (mm->hmap == NULL)
+    {
+        fprintf(stderr, "error: CreateFileMapping(): ret=0x%08x\n",
+            GetLastError());
+        CloseHandle(mm->h);
+        return false;
+    }
+
+    mm->map = MapViewOfFile(mm->hmap, FILE_MAP_WRITE | FILE_MAP_READ,
+                            0, 0, 0);
+    if(mm->map == NULL)
+    {
+        fprintf(stderr, "error: MapViewOfFile(): ret=0x%08x\n",
+            GetLastError());
+        CloseHandle(mm->hmap);
+        CloseHandle(mm->h);
+        return false;
+    }
+
+    return true;
+}
+#endif
+
+
+/*
+ * posix memory mapped files
+ */
+
+#if defined OS_POSIX
+struct xi_nub_mm
+{
+    int fd;
+    void *map;
+};
+#endif
+
+#if defined OS_POSIX
+static bool _map_file(xi_nub_mm *mm, const char *fname,
+    share_mode smode, size_t length)
+{
+    int oflags = 0;
+    switch (smode) {
+    case file_create_always:     oflags = O_CREAT | O_TRUNC; break;
+    case file_create_new:        oflags = O_CREAT | O_EXCL;  break;
+    case file_open_existing:     oflags = 0;                 break;
+    case file_open_always:       oflags = O_CREAT;           break;
+    case file_truncate_existing: oflags = O_TRUNC;           break;
+    }
+    mm->fd = open(fname, O_RDWR | oflags, 0644);
+    if (mm->fd < 0) {
+        fprintf(stderr, "error: open(\"%s\"): %s\n",fname, strerror(errno));
+        return false;
+    }
+
+    /* truncate file */
+    if (length) {
+        int ret = ftruncate(mm->fd, length);
+        if (ret < 0) {
+            fprintf(stderr, "error: ftruncate(): %s\n", strerror(errno));
+            close(mm->fd);
+            return false;
+        }
+    } else {
+        struct stat s;
+        if (fstat(mm->fd, &s) < 0) {
+            fprintf(stderr, "error: fstat(): %s\n", strerror(errno));
+            close(mm->fd);
+            return false;
+        }
+        length = s.st_size;
+    }
+
+    /* memory map file */
+    off_t offset = 0;
+    mm->map = mmap(NULL, length, PROT_READ|PROT_WRITE, MAP_SHARED,
+                      mm->fd, offset);
+    if (mm->map == NULL) {
+        fprintf(stderr, "error: mmap(): %s\n", strerror(errno));
+        close(mm->fd);
+        return false;
+    }
+
+    return true;
+}
+#endif
+
+
+/*
+ * windows file io
+ */
+
+#if defined OS_WINDOWS
+static xi_nub_result _read(xi_nub_win32_file *file, void *buf, size_t len)
+{
+    DWORD nbytes;
+    BOOL ret = ReadFile(file->h, buf, (DWORD)len, &nbytes, NULL);
+    return xi_nub_result{ os_error_code(GetLastError()), ret ? nbytes : -1 };
+}
+
+static xi_nub_result _write(xi_nub_win32_file *file, void *buf, size_t len)
+{
+    DWORD nbytes;
+    BOOL ret = WriteFile(file->h, buf, (DWORD)len, &nbytes, NULL);
+    return xi_nub_result{ os_error_code(GetLastError()), ret ? nbytes : -1 };
+}
+
+static xi_nub_result _disconnect(xi_nub_win32_file *file)
+{
+    BOOL ret = DisconnectNamedPipe(file->h);
+    return xi_nub_result{ os_error_code(GetLastError()), ret ? 0 : -1 };
+}
+
+static xi_nub_result _close(xi_nub_win32_file *file)
+{
+    BOOL ret = CloseHandle(file->h);
+    return xi_nub_result{ os_error_code(GetLastError()), ret ? 0 : -1 };
+}
+#endif
+
+
+/*
+ * posix file io
+ */
+
+#if defined OS_POSIX
+static xi_nub_result _read(xi_nub_unix_file *file, void *buf, size_t len)
+{
+    intptr_t ret = read(file->fd, buf, len);
+    return xi_nub_result{ os_error_code(errno), ret };
+}
+
+static xi_nub_result _write(xi_nub_unix_file *file, void *buf, size_t len)
+{
+    intptr_t ret = write(file->fd, buf, len);
+    return xi_nub_result{ os_error_code(errno), ret };
+}
+
+static xi_nub_result _disconnect(xi_nub_unix_file *file)
+{
+    intptr_t ret = close(file->fd);
+    return xi_nub_result{ os_error_code(errno), ret };
+}
+
+static xi_nub_result _close(xi_nub_unix_file *file)
+{
+    intptr_t ret = close(file->fd);
+    return xi_nub_result{ os_error_code(errno), ret };
+}
+#endif
+
+
+/*
+ * windows sockets
+ */
+
+#if defined OS_WINDOWS
+typedef xi_nub_win32_sock xi_nub_platform_sock;
+#endif
+
+#if defined OS_WINDOWS
+static xi_nub_platform_sock listen_socket_create()
+{
+    DWORD open_mode = PIPE_ACCESS_DUPLEX;
+    DWORD pipe_mode = PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT;
+    LPWSTR pipe_name = L"\\\\.\\pipe\\Xi";
+    DWORD buf_size = 65536;
+
+    HANDLE h = CreateNamedPipeW(pipe_name, open_mode, pipe_mode,
+                                    PIPE_UNLIMITED_INSTANCES,
+                                    buf_size, buf_size,
+                                    NMPWAIT_USE_DEFAULT_WAIT, NULL);
+    if (h == INVALID_HANDLE_VALUE)
+    {
+        fprintf(stderr, "error: CreateNamedPipe(): ret=0x%08x\n", GetLastError());
+        return xi_nub_platform_sock(INVALID_HANDLE_VALUE, GetLastError());
+    }
+
+    return xi_nub_platform_sock(h, GetLastError());
+}
+#endif
+
+#if defined OS_WINDOWS
+static xi_nub_platform_sock listen_socket_accept(xi_nub_platform_sock l)
+{
+    /*
+     * we only connect one socket and then must create a new pipe
+     * to accept subsequent connections
+     */
+    int ret = ConnectNamedPipe(l.h, NULL);
+    if (ret || (GetLastError() == ERROR_PIPE_CONNECTED)) {
+        return xi_nub_platform_sock(l.h, GetLastError());
+    } else {
+        return xi_nub_platform_sock(INVALID_HANDLE_VALUE, GetLastError());
+    }
+}
+#endif
+
+#if defined OS_WINDOWS
+static xi_nub_platform_sock client_socket_connect()
+{
+    LPWSTR pipe_name = L"\\\\.\\pipe\\Xi";
+
+    DWORD buf_size = 65536;
+
+    HANDLE h = CreateFileW(pipe_name, GENERIC_READ | GENERIC_WRITE,
+                               0, NULL, OPEN_EXISTING, 0, NULL);
+    if (h == INVALID_HANDLE_VALUE)
+    {
+        fprintf(stderr, "error: CreateFile(): ret=0x%08x\n", GetLastError());
+        return xi_nub_platform_sock(INVALID_HANDLE_VALUE, GetLastError());
+    }
+
+    return xi_nub_platform_sock(h, GetLastError());
+}
+#endif
+
+
+/*
+ * posix sockets
+ */
+
+#if defined OS_POSIX
+typedef xi_nub_unix_sock xi_nub_platform_sock;
+#endif
+
+#if defined OS_POSIX
+static xi_nub_platform_sock listen_socket_create()
+{
+    const char *pipe_path = "Xi";
+    sockaddr_un saddr;
+
+    memset(&saddr, 0, sizeof(saddr));
+    saddr.sun_family = AF_UNIX;
+
+    size_t saddr_len = offsetof(sockaddr_un,sun_path) + strlen(pipe_path) + 1;
+    strncpy(saddr.sun_path + 1, pipe_path, strlen(pipe_path));
+
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        fprintf(stderr, "error: socket(): %s\n", strerror(errno));
+        return xi_nub_platform_sock(-1, errno);
+    }
+
+    int enable = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0) {
+        fprintf(stderr, "error: setsockopt(): %s\n", strerror(errno));
+        close(fd);
+        return xi_nub_platform_sock(-1, errno);
+    }
+
+    if (bind(fd, (sockaddr*)(&saddr), saddr_len) < 0) {
+        fprintf(stderr, "error: bind(): %s\n", strerror(errno));
+        close(fd);
+        return xi_nub_platform_sock(-1, errno);
+    }
+
+    if (listen(fd, 256) < 0) {
+        fprintf(stderr, "error: listen(): %s\n", strerror(errno));
+        close(fd);
+        return xi_nub_platform_sock(-1, errno);
+    }
+
+    return xi_nub_platform_sock(fd, 0);
+}
+#endif
+
+#if defined OS_POSIX
+static xi_nub_platform_sock listen_socket_accept(xi_nub_platform_sock l)
+{
+    struct sockaddr saddr;
+    socklen_t saddrlen = sizeof(saddr);
+
+    int fd = accept(l.fd, &saddr, &saddrlen);
+    if (fd < 0) {
+        fprintf(stderr, "error: accept failed: %s\n", strerror(errno));
+        return xi_nub_platform_sock(-1, errno);
+    }
+
+    return xi_nub_platform_sock(fd, 0);
+}
+#endif
+
+#if defined OS_POSIX
+static xi_nub_platform_sock client_socket_connect()
+{
+    const char *pipe_path = "Xi";
+    sockaddr_un saddr;
+
+    memset(&saddr, 0, sizeof(saddr));
+    saddr.sun_family = AF_UNIX;
+
+    size_t saddr_len = offsetof(sockaddr_un,sun_path) + strlen(pipe_path) + 1;
+    strncpy(saddr.sun_path + 1, pipe_path, strlen(pipe_path));
+
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        fprintf(stderr, "error: socket(): %s\n", strerror(errno));
+        return xi_nub_platform_sock(-1, errno);
+    }
+
+    if (connect(fd, (sockaddr*)(&saddr), saddr_len) < 0) {
+        fprintf(stderr, "error: bind(): %s\n", strerror(errno));
+        close(fd);
+        return xi_nub_platform_sock(-1, errno);
+    }
+    return xi_nub_platform_sock(fd, 0);
+}
+#endif
+
+
+/*
+ * nub server
+ */
+
+xi_nub_server* xi_nub_server_new(xi_nub_ctx *ctx, int argc, const char **argv)
+{
+    xi_nub_server *s = (xi_nub_server *)calloc(1, sizeof(xi_nub_server));
+    s->ctx = xi_nub_ctx_get_root_context();
+    if (debug) printf("xi_nub_server_new: server=%p\n", s);
+    return s;
+}
+
+void xi_nub_server_accept(xi_nub_server *server, int nthreads, xi_nub_accept_cb cb)
+{
+    xi_nub_platform_sock listen = listen_socket_create();
+    if (debug) {
+        printf("xi_nub_server_accept: listening sock=%s\n", listen.identity());
+    }
+
+    for (;;) {
+        xi_nub_platform_sock sock = listen_socket_accept(listen);
+        if (debug) {
+            printf("xi_nub_server_accept: accepted sock=%s\n", sock.identity());
+        }
+
+        xi_nub_conn conn;
+        conn.ctx = server->ctx;
+        conn.server = server;
+        conn.sock = new xi_nub_platform_sock(sock);
+
+        if (sock.has_error()) cb(&conn, sock.error_code());
+        else cb(&conn, xi_nub_success);
+
+        /* TODO - implement server shutdown */
+    }
+}
+
+
+/*
+ * nub client
+ */
+
+xi_nub_client* xi_nub_client_new(xi_nub_ctx *ctx, int argc, const char **argv)
+{
+    xi_nub_client *c = (xi_nub_client *)calloc(1, sizeof(xi_nub_client));
+    c->ctx = xi_nub_ctx_get_root_context();
+    if (debug) {
+        printf("xi_nub_client_new: client=%p\n", c);
+    }
+    return c;
+}
+
+void xi_nub_client_connect(xi_nub_client *client, int nthreads, xi_nub_connect_cb cb)
+{
+    xi_nub_platform_sock sock = client_socket_connect();
+    if (debug) {
+        printf("xi_nub_client_connect: sock=%s\n", sock.identity());
+    }
+
+    xi_nub_conn conn;
+    conn.ctx = client->ctx;
+    conn.client = client;
+    conn.sock = new xi_nub_platform_sock(sock);
+
+    if (sock.has_error()) cb(&conn, sock.error_code());
+    else cb(&conn, xi_nub_success);
+}
+
+
+/*
+ * nub connection io
+ */
+
+void xi_nub_conn_read(xi_nub_conn *conn, void *buf, size_t len, xi_nub_read_cb cb)
+{
+    auto file = reinterpret_cast<xi_nub_platform_sock*>(conn->sock);
+    xi_nub_result result = _read(file, buf, len);
+    if (debug) {
+        printf("xi_nub_conn_read: sock=%s, len=%zu: ret=%zd, error=%d\n",
+            conn->sock->identity(), len, result.bytes, result.error);
+    }
+    if (cb) cb(conn, result.error, buf, result.bytes);
+}
+
+void xi_nub_conn_write(xi_nub_conn *conn, void *buf, size_t len, xi_nub_write_cb cb)
+{
+    auto file = reinterpret_cast<xi_nub_platform_sock*>(conn->sock);
+    xi_nub_result result = _write(file, buf, len);
+    if (debug) {
+        printf("xi_nub_conn_write: sock=%s, len=%zu: ret=%zd, error=%d\n",
+            conn->sock->identity(), len, result.bytes, result.error);
+    }
+    if (cb) cb(conn, result.error, buf, result.bytes);
+}
+
+void xi_nub_conn_close(xi_nub_conn *conn, xi_nub_close_cb cb)
+{
+    auto file = reinterpret_cast<xi_nub_platform_sock*>(conn->sock);
+    xi_nub_result result = conn->server ? _disconnect(file) : _close(file);
+    if (debug) {
+        printf("xi_nub_conn_close: sock=%s: ret=%zd, error=%d\n",
+            conn->sock->identity(), result.bytes, result.error);
+    }
+    if (cb) cb(conn, result.error);
+}
+
+const char* xi_nub_conn_get_identity(xi_nub_conn *conn)
+{
+    return conn->sock->identity();
+}
+
+
+/*
+ * nub accessors
+ */
+
+void xi_nub_conn_set_user_data(xi_nub_conn *conn, void *data) { conn->user_data = data; }
+void* xi_nub_conn_get_user_data(xi_nub_conn *conn) { return conn->user_data; }
+xi_nub_client* xi_nub_conn_get_client(xi_nub_conn *conn) { return conn->client; }
+xi_nub_server* xi_nub_conn_get_server(xi_nub_conn *conn) { return conn->server; }
+xi_nub_ctx* xi_nub_conn_get_context(xi_nub_conn *conn) { return conn->ctx; }
+
+void xi_nub_ctx_set_user_data(xi_nub_ctx *ctx, void *data) { ctx->user_data = data; }
+void* xi_nub_ctx_get_user_data(xi_nub_ctx *ctx) { return ctx->user_data; }
+const char* xi_nub_ctx_get_profile_path(xi_nub_ctx *ctx) { return ctx->profile_path.c_str(); }
+
+
+/*
+ * nub context
+ */
+
+void xi_nub_init(xi_nub_ctx *ctx)
+{
+    /* find user profile directory */
+    xi_nub_find_dirs(ctx);
+
+    /* create profile directory if it does not exist */
+    if (!directory_exists(ctx->profile_path.c_str())) {
+        if(!make_directory(ctx->profile_path.c_str())) {
+            fprintf(stderr, "error: make_directory failed: %s\n",
+                ctx->profile_path.c_str());
+        }
+    }
+}
+
+xi_nub_ctx* xi_nub_ctx_get_root_context()
+{
+    static xi_nub_ctx ctx;
+
+    /* TODO - this needs to be atomic */
+    if (ctx.profile_path.size() == 0) {
+        xi_nub_init(&ctx);
+    }
+
+    return &ctx;
+}

--- a/src/xi_nub.cc
+++ b/src/xi_nub.cc
@@ -240,28 +240,3 @@ xi_nub_ctx* xi_nub_ctx_get_root_context()
 
     return &ctx;
 }
-
-void xi_nub_semaphore()
-{
-    char sem_file[MAXPATHLEN];
-    xi_nub_ctx* ctx = xi_nub_ctx_get_root_context();
-    const char* profile_path = xi_nub_ctx_get_profile_path(ctx);
-    snprintf(sem_file, sizeof(sem_file), "%s%s", profile_path,
-        PATH_SEPARATOR "semaphore.bin");
-
-    printf("semaphore file: %s\n", sem_file);
-
-    bool leader = false;
-    auto f = _open_file(sem_file, file_create_new, file_append);
-    if (f.has_error()) {
-        f = _open_file(sem_file, file_open_existing, file_append);
-    } else {
-        leader = true;
-    }
-    uint32_t pid = (uint32_t)_get_processs_id();
-    _write(&f, &pid, sizeof(pid));
-    xi_nub_result off = _get_file_offset(&f);
-    uint32_t ticket = (uint32_t)off.bytes >> 2;
-    _close(&f);
-    printf("leader=%u pid=%u ticket=%u\n", leader, pid, ticket);
-}

--- a/src/xi_nub.cc
+++ b/src/xi_nub.cc
@@ -16,98 +16,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <cerrno>
+#include "xi_common.h"
 
-#include <string>
-#include <vector>
-
-#ifdef _WIN32
-#define OS_WINDOWS
-#endif
-
-#ifdef __APPLE__
-#define OS_MACOS
-#define OS_POSIX
-#endif
-
-#ifdef __linux__
-#define OS_LINUX
-#define OS_POSIX
-#endif
-
-#if defined OS_WINDOWS
-#include <windows.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#endif
-
-#if defined OS_POSIX
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/mman.h>
-#include <sys/un.h>
-#include <sys/socket.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <pwd.h>
-#endif
-
-#include "xi_nub.h"
-
-#if !defined MAXPATHLEN && defined MAX_PATH
-#define MAXPATHLEN MAX_PATH
-#endif
-
-
-/*
- * nub globals
- */
-
-static bool debug = false;
-
-#if defined OS_WINDOWS
-const char *profile_template = "%s\\Xi";
-#elif defined OS_MACOS
-const char *profile_template = "%s/Library/Application Support/Xi";
-#elif defined OS_LINUX
-const char *profile_template =  "%s/.config/Xi";
-#endif
-
-
-/*
- * nub private structures
- */
-
-enum share_mode {
-    file_create_always,
-    file_create_new,
-    file_open_existing,
-    file_open_always,
-    file_truncate_existing
-};
-
-struct xi_nub_result {
-    xi_nub_error error;
-    intptr_t bytes;
-};
-
-struct xi_nub_file
-{
-    virtual const char* identity() = 0;
-    virtual bool has_error() = 0;
-    virtual int os_error() = 0;
-    virtual xi_nub_error error_code() = 0;
-    virtual ~xi_nub_file() = 0;
-};
-
-xi_nub_file::~xi_nub_file() {}
-
-typedef xi_nub_file xi_nub_sock;
 
 struct xi_nub_ctx
 {
@@ -138,175 +48,16 @@ struct xi_nub_conn
 
 
 /*
- * platform error mapping
- */
-
-#if defined OS_WINDOWS
-static xi_nub_error os_error_code(DWORD error) {
-    switch (error) {
-    case 0:                    return xi_nub_success;
-    case ERROR_INVALID_HANDLE: return xi_nub_einval;
-    case ERROR_FILE_NOT_FOUND:
-    case ERROR_PIPE_BUSY:
-    case ERROR_PIPE_NOT_CONNECTED:
-                               return xi_nub_econnrefused;
-    default:                   return xi_nub_egeneric;
-    }
-}
-#endif
-
-#if defined OS_POSIX
-static xi_nub_error os_error_code(int error) {
-    switch (error) {
-    case 0:             return xi_nub_success;
-    case EINVAL:        return xi_nub_einval;
-    case ECONNREFUSED:  return xi_nub_econnrefused;
-    default:            return xi_nub_egeneric;
-    }
-}
-#endif
-
-
-/*
- * windows file descriptor
- */
-
-#if defined OS_WINDOWS
-struct xi_nub_win32_file : xi_nub_file
-{
-    HANDLE h;
-    DWORD error;
-    char ident[32];
-
-    xi_nub_win32_file(HANDLE h, DWORD error = GetLastError())
-        : h(h), error(error) {}
-
-    virtual const char* identity() {
-        snprintf(ident, sizeof(ident), "handle(%lld)", (long long)h);
-        return ident;
-    }
-
-    virtual bool has_error() { return h == INVALID_HANDLE_VALUE; }
-    virtual int os_error() { return error; }
-    virtual xi_nub_error error_code() { return os_error_code(error); }
-};
-#endif
-
-#if defined OS_WINDOWS
-typedef xi_nub_win32_file xi_nub_win32_sock;
-#endif
-
-
-/*
- * posix file descriptor
- */
-
-#if defined OS_POSIX
-struct xi_nub_unix_file : xi_nub_file
-{
-    int fd;
-    int error;
-    char ident[32];
-
-    xi_nub_unix_file(int fd, int error = errno)
-        : fd(fd), error(error) {}
-
-    virtual const char* identity() {
-        snprintf(ident, sizeof(ident), "fd(%d)", fd);
-        return ident;
-    }
-
-    virtual bool has_error() { return fd < 0;}
-    virtual int os_error() { return error; }
-    virtual xi_nub_error error_code() { return os_error_code(error); }
-};
-#endif
-
-#if defined OS_POSIX
-typedef xi_nub_unix_file xi_nub_unix_sock;
-#endif
-
-
-/*
- * utf8 <-> utf16 string conversion
- */
-
-using string = std::string;
-using wstring = std::wstring;
-
-#if defined OS_WINDOWS
-static string utf16_to_utf8(const wstring w)
-{
-    int l = WideCharToMultiByte(CP_UTF8, 0, &w[0], (int)w.size(), NULL, 0, NULL, NULL);
-    string s(l, 0);
-    WideCharToMultiByte(CP_UTF8, 0, &w[0], (int)w.size(), &s[0], l, NULL, NULL);
-    return s;
-}
-#endif
-
-#if defined OS_WINDOWS
-static wstring utf8_to_utf16(const string s)
-{
-    int l = MultiByteToWideChar(CP_UTF8, 0, &s[0], (int)s.size(), NULL, 0);
-    wstring w(l, 0);
-    MultiByteToWideChar(CP_UTF8, 0, &s[0], (int)s.size(), &w[0], l);
-    return w;
-}
-#endif
-
-
-/*
- * filesystem helpers
- */
-
-#if defined OS_WINDOWS
-static bool directory_exists(const char *path)
-{
-    DWORD dwAttrib = GetFileAttributesW(utf8_to_utf16(path).c_str());
-    return (dwAttrib != INVALID_FILE_ATTRIBUTES &&
-           (dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
-}
-#endif
-
-#if defined OS_WINDOWS
-static bool make_directory(const char *path)
-{
-    return CreateDirectoryW(utf8_to_utf16(path).c_str(), NULL) != 0;
-}
-#endif
-
-#if defined OS_POSIX
-static bool directory_exists(const char *path)
-{
-    struct stat sb;
-    int ret = stat(path, &sb);
-    return ret == 0 && ((sb.st_mode & S_IFMT) == S_IFDIR);
-}
-#endif
-
-#if defined OS_POSIX
-static bool make_directory(const char *path)
-{
-    return mkdir(path, 0777) == 0;
-}
-#endif
-
-#if defined OS_WINDOWS
-static std::string windows_getenv(const char *name)
-{
-    size_t len;
-    std::string s;
-    getenv_s(&len, NULL, 0, name);
-    s.resize(len);
-    getenv_s(&len, s.data(), len, name);
-    return s;
-}
-#endif
-
-
-/*
  * profile directory
  */
+
+#if defined OS_WINDOWS
+const char *profile_template = "%s\\Xi";
+#elif defined OS_MACOS
+const char *profile_template = "%s/Library/Application Support/Xi";
+#elif defined OS_LINUX
+const char *profile_template =  "%s/.config/Xi";
+#endif
 
 #if defined OS_WINDOWS
 static void xi_nub_find_dirs(xi_nub_ctx *ctx)
@@ -329,369 +80,6 @@ static void xi_nub_find_dirs(xi_nub_ctx *ctx)
     ctx->home_path = p->pw_dir;
     snprintf(profile_path_tmp, MAXPATHLEN, profile_template, ctx->home_path.c_str());
     ctx->profile_path = profile_path_tmp;
-}
-#endif
-
-
-/*
- * windows memory mapped files
- */
-
-#if defined OS_WINDOWS
-struct xi_nub_mm
-{
-    HANDLE h;
-    HANDLE hmap;
-    void *map;
-};
-#endif
-
-#if defined OS_WINDOWS
-static bool _map_file(xi_nub_mm *mm, const char *fname,
-    share_mode smode, size_t length)
-{
-    DWORD omode = 0;
-    switch (smode) {
-    case file_create_always:     omode = CREATE_ALWAYS;     break;
-    case file_create_new:        omode = CREATE_NEW;        break;
-    case file_open_existing:     omode = OPEN_EXISTING;     break;
-    case file_open_always:       omode = OPEN_ALWAYS;       break;
-    case file_truncate_existing: omode = TRUNCATE_EXISTING; break;
-    }
-    mm->h = CreateFile(fname, GENERIC_READ | GENERIC_WRITE, 0, NULL, omode,
-                       FILE_FLAG_RANDOM_ACCESS, NULL);
-    if (mm->h == INVALID_HANDLE_VALUE)
-    {
-        fprintf(stderr, "error: CreateFile(\"%s\"): ret=0x%08x\n",
-            fname, GetLastError());
-        return false;
-    }
-
-    /* truncate file */
-    if (length) {
-        SetFileValidData(mm->h, length);
-        if (!SetEndOfFile(mm->h)) {
-            fprintf(stderr, "error: SetEndOfFile(): ret=0x%08x\n",
-                GetLastError());
-            CloseHandle(mm->h);
-            return false;
-        }
-    } else {
-        _BY_HANDLE_FILE_INFORMATION file_info;
-        GetFileInformationByHandle(mm->h, &file_info);
-        length = (size_t)file_info.nFileSizeLow |
-            ((size_t)file_info.nFileSizeHigh << 32);
-    }
-
-    /* memory map file */
-    mm->hmap = CreateFileMapping(mm->h, NULL, PAGE_READWRITE |SEC_RESERVE,
-                                 0, 0, 0);
-    if (mm->hmap == NULL)
-    {
-        fprintf(stderr, "error: CreateFileMapping(): ret=0x%08x\n",
-            GetLastError());
-        CloseHandle(mm->h);
-        return false;
-    }
-
-    mm->map = MapViewOfFile(mm->hmap, FILE_MAP_WRITE | FILE_MAP_READ,
-                            0, 0, 0);
-    if(mm->map == NULL)
-    {
-        fprintf(stderr, "error: MapViewOfFile(): ret=0x%08x\n",
-            GetLastError());
-        CloseHandle(mm->hmap);
-        CloseHandle(mm->h);
-        return false;
-    }
-
-    return true;
-}
-#endif
-
-
-/*
- * posix memory mapped files
- */
-
-#if defined OS_POSIX
-struct xi_nub_mm
-{
-    int fd;
-    void *map;
-};
-#endif
-
-#if defined OS_POSIX
-static bool _map_file(xi_nub_mm *mm, const char *fname,
-    share_mode smode, size_t length)
-{
-    int oflags = 0;
-    switch (smode) {
-    case file_create_always:     oflags = O_CREAT | O_TRUNC; break;
-    case file_create_new:        oflags = O_CREAT | O_EXCL;  break;
-    case file_open_existing:     oflags = 0;                 break;
-    case file_open_always:       oflags = O_CREAT;           break;
-    case file_truncate_existing: oflags = O_TRUNC;           break;
-    }
-    mm->fd = open(fname, O_RDWR | oflags, 0644);
-    if (mm->fd < 0) {
-        fprintf(stderr, "error: open(\"%s\"): %s\n",fname, strerror(errno));
-        return false;
-    }
-
-    /* truncate file */
-    if (length) {
-        int ret = ftruncate(mm->fd, length);
-        if (ret < 0) {
-            fprintf(stderr, "error: ftruncate(): %s\n", strerror(errno));
-            close(mm->fd);
-            return false;
-        }
-    } else {
-        struct stat s;
-        if (fstat(mm->fd, &s) < 0) {
-            fprintf(stderr, "error: fstat(): %s\n", strerror(errno));
-            close(mm->fd);
-            return false;
-        }
-        length = s.st_size;
-    }
-
-    /* memory map file */
-    off_t offset = 0;
-    mm->map = mmap(NULL, length, PROT_READ|PROT_WRITE, MAP_SHARED,
-                      mm->fd, offset);
-    if (mm->map == NULL) {
-        fprintf(stderr, "error: mmap(): %s\n", strerror(errno));
-        close(mm->fd);
-        return false;
-    }
-
-    return true;
-}
-#endif
-
-
-/*
- * windows file io
- */
-
-#if defined OS_WINDOWS
-static xi_nub_result _read(xi_nub_win32_file *file, void *buf, size_t len)
-{
-    DWORD nbytes;
-    BOOL ret = ReadFile(file->h, buf, (DWORD)len, &nbytes, NULL);
-    return xi_nub_result{ os_error_code(GetLastError()), ret ? nbytes : -1 };
-}
-
-static xi_nub_result _write(xi_nub_win32_file *file, void *buf, size_t len)
-{
-    DWORD nbytes;
-    BOOL ret = WriteFile(file->h, buf, (DWORD)len, &nbytes, NULL);
-    return xi_nub_result{ os_error_code(GetLastError()), ret ? nbytes : -1 };
-}
-
-static xi_nub_result _disconnect(xi_nub_win32_file *file)
-{
-    BOOL ret = DisconnectNamedPipe(file->h);
-    return xi_nub_result{ os_error_code(GetLastError()), ret ? 0 : -1 };
-}
-
-static xi_nub_result _close(xi_nub_win32_file *file)
-{
-    BOOL ret = CloseHandle(file->h);
-    return xi_nub_result{ os_error_code(GetLastError()), ret ? 0 : -1 };
-}
-#endif
-
-
-/*
- * posix file io
- */
-
-#if defined OS_POSIX
-static xi_nub_result _read(xi_nub_unix_file *file, void *buf, size_t len)
-{
-    intptr_t ret = read(file->fd, buf, len);
-    return xi_nub_result{ os_error_code(errno), ret };
-}
-
-static xi_nub_result _write(xi_nub_unix_file *file, void *buf, size_t len)
-{
-    intptr_t ret = write(file->fd, buf, len);
-    return xi_nub_result{ os_error_code(errno), ret };
-}
-
-static xi_nub_result _disconnect(xi_nub_unix_file *file)
-{
-    intptr_t ret = close(file->fd);
-    return xi_nub_result{ os_error_code(errno), ret };
-}
-
-static xi_nub_result _close(xi_nub_unix_file *file)
-{
-    intptr_t ret = close(file->fd);
-    return xi_nub_result{ os_error_code(errno), ret };
-}
-#endif
-
-
-/*
- * windows sockets
- */
-
-#if defined OS_WINDOWS
-typedef xi_nub_win32_sock xi_nub_platform_sock;
-#endif
-
-#if defined OS_WINDOWS
-static xi_nub_platform_sock listen_socket_create()
-{
-    DWORD open_mode = PIPE_ACCESS_DUPLEX;
-    DWORD pipe_mode = PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT;
-    LPWSTR pipe_name = L"\\\\.\\pipe\\Xi";
-    DWORD buf_size = 65536;
-
-    HANDLE h = CreateNamedPipeW(pipe_name, open_mode, pipe_mode,
-                                    PIPE_UNLIMITED_INSTANCES,
-                                    buf_size, buf_size,
-                                    NMPWAIT_USE_DEFAULT_WAIT, NULL);
-    if (h == INVALID_HANDLE_VALUE)
-    {
-        fprintf(stderr, "error: CreateNamedPipe(): ret=0x%08x\n", GetLastError());
-        return xi_nub_platform_sock(INVALID_HANDLE_VALUE, GetLastError());
-    }
-
-    return xi_nub_platform_sock(h, GetLastError());
-}
-#endif
-
-#if defined OS_WINDOWS
-static xi_nub_platform_sock listen_socket_accept(xi_nub_platform_sock l)
-{
-    /*
-     * we only connect one socket and then must create a new pipe
-     * to accept subsequent connections
-     */
-    int ret = ConnectNamedPipe(l.h, NULL);
-    if (ret || (GetLastError() == ERROR_PIPE_CONNECTED)) {
-        return xi_nub_platform_sock(l.h, GetLastError());
-    } else {
-        return xi_nub_platform_sock(INVALID_HANDLE_VALUE, GetLastError());
-    }
-}
-#endif
-
-#if defined OS_WINDOWS
-static xi_nub_platform_sock client_socket_connect()
-{
-    LPWSTR pipe_name = L"\\\\.\\pipe\\Xi";
-
-    DWORD buf_size = 65536;
-
-    HANDLE h = CreateFileW(pipe_name, GENERIC_READ | GENERIC_WRITE,
-                               0, NULL, OPEN_EXISTING, 0, NULL);
-    if (h == INVALID_HANDLE_VALUE)
-    {
-        fprintf(stderr, "error: CreateFile(): ret=0x%08x\n", GetLastError());
-        return xi_nub_platform_sock(INVALID_HANDLE_VALUE, GetLastError());
-    }
-
-    return xi_nub_platform_sock(h, GetLastError());
-}
-#endif
-
-
-/*
- * posix sockets
- */
-
-#if defined OS_POSIX
-typedef xi_nub_unix_sock xi_nub_platform_sock;
-#endif
-
-#if defined OS_POSIX
-static xi_nub_platform_sock listen_socket_create()
-{
-    const char *pipe_path = "Xi";
-    sockaddr_un saddr;
-
-    memset(&saddr, 0, sizeof(saddr));
-    saddr.sun_family = AF_UNIX;
-
-    size_t saddr_len = offsetof(sockaddr_un,sun_path) + strlen(pipe_path) + 1;
-    strncpy(saddr.sun_path + 1, pipe_path, strlen(pipe_path));
-
-    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (fd < 0) {
-        fprintf(stderr, "error: socket(): %s\n", strerror(errno));
-        return xi_nub_platform_sock(-1, errno);
-    }
-
-    int enable = 1;
-    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0) {
-        fprintf(stderr, "error: setsockopt(): %s\n", strerror(errno));
-        close(fd);
-        return xi_nub_platform_sock(-1, errno);
-    }
-
-    if (bind(fd, (sockaddr*)(&saddr), saddr_len) < 0) {
-        fprintf(stderr, "error: bind(): %s\n", strerror(errno));
-        close(fd);
-        return xi_nub_platform_sock(-1, errno);
-    }
-
-    if (listen(fd, 256) < 0) {
-        fprintf(stderr, "error: listen(): %s\n", strerror(errno));
-        close(fd);
-        return xi_nub_platform_sock(-1, errno);
-    }
-
-    return xi_nub_platform_sock(fd, 0);
-}
-#endif
-
-#if defined OS_POSIX
-static xi_nub_platform_sock listen_socket_accept(xi_nub_platform_sock l)
-{
-    struct sockaddr saddr;
-    socklen_t saddrlen = sizeof(saddr);
-
-    int fd = accept(l.fd, &saddr, &saddrlen);
-    if (fd < 0) {
-        fprintf(stderr, "error: accept failed: %s\n", strerror(errno));
-        return xi_nub_platform_sock(-1, errno);
-    }
-
-    return xi_nub_platform_sock(fd, 0);
-}
-#endif
-
-#if defined OS_POSIX
-static xi_nub_platform_sock client_socket_connect()
-{
-    const char *pipe_path = "Xi";
-    sockaddr_un saddr;
-
-    memset(&saddr, 0, sizeof(saddr));
-    saddr.sun_family = AF_UNIX;
-
-    size_t saddr_len = offsetof(sockaddr_un,sun_path) + strlen(pipe_path) + 1;
-    strncpy(saddr.sun_path + 1, pipe_path, strlen(pipe_path));
-
-    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (fd < 0) {
-        fprintf(stderr, "error: socket(): %s\n", strerror(errno));
-        return xi_nub_platform_sock(-1, errno);
-    }
-
-    if (connect(fd, (sockaddr*)(&saddr), saddr_len) < 0) {
-        fprintf(stderr, "error: bind(): %s\n", strerror(errno));
-        close(fd);
-        return xi_nub_platform_sock(-1, errno);
-    }
-    return xi_nub_platform_sock(fd, 0);
 }
 #endif
 
@@ -833,9 +221,9 @@ void xi_nub_init(xi_nub_ctx *ctx)
     xi_nub_find_dirs(ctx);
 
     /* create profile directory if it does not exist */
-    if (!directory_exists(ctx->profile_path.c_str())) {
-        if(!make_directory(ctx->profile_path.c_str())) {
-            fprintf(stderr, "error: make_directory failed: %s\n",
+    if (!_directory_exists(ctx->profile_path.c_str())) {
+        if(!_make_directory(ctx->profile_path.c_str())) {
+            fprintf(stderr, "error: _make_directory failed: %s\n",
                 ctx->profile_path.c_str());
         }
     }
@@ -851,4 +239,29 @@ xi_nub_ctx* xi_nub_ctx_get_root_context()
     }
 
     return &ctx;
+}
+
+void xi_nub_semaphore()
+{
+    char sem_file[MAXPATHLEN];
+    xi_nub_ctx* ctx = xi_nub_ctx_get_root_context();
+    const char* profile_path = xi_nub_ctx_get_profile_path(ctx);
+    snprintf(sem_file, sizeof(sem_file), "%s%s", profile_path,
+        PATH_SEPARATOR "semaphore.bin");
+
+    printf("semaphore file: %s\n", sem_file);
+
+    bool leader = false;
+    auto f = _open_file(sem_file, file_create_new, file_append);
+    if (f.has_error()) {
+        f = _open_file(sem_file, file_open_existing, file_append);
+    } else {
+        leader = true;
+    }
+    uint32_t pid = (uint32_t)_get_processs_id();
+    _write(&f, &pid, sizeof(pid));
+    xi_nub_result off = _get_file_offset(&f);
+    uint32_t ticket = (uint32_t)off.bytes >> 2;
+    _close(&f);
+    printf("leader=%u pid=%u ticket=%u\n", leader, pid, ticket);
 }

--- a/src/xi_nub.h
+++ b/src/xi_nub.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 /*
  * const char* argv[] = { "Xi", "nub-server" };
  *
@@ -45,6 +47,8 @@ typedef enum
 {
 	xi_nub_success,
 	xi_nub_einval,
+	xi_nub_eexist,
+	xi_nub_eacces,
 	xi_nub_econnrefused,
 	xi_nub_egeneric = 255
 } xi_nub_error;
@@ -81,6 +85,8 @@ xi_nub_ctx* xi_nub_ctx_get_root_context();
 const char* xi_nub_ctx_get_profile_path(xi_nub_ctx *ctx);
 void xi_nub_ctx_set_user_data(xi_nub_ctx *ctx, void *data);
 void* xi_nub_ctx_get_user_data(xi_nub_ctx *ctx);
+
+void xi_nub_semaphore();
 
 #ifdef __cplusplus
 }

--- a/src/xi_nub.h
+++ b/src/xi_nub.h
@@ -50,6 +50,8 @@ typedef enum
 	xi_nub_eexist,
 	xi_nub_eacces,
 	xi_nub_econnrefused,
+	xi_nub_eagain,
+	xi_nub_eio,
 	xi_nub_egeneric = 255
 } xi_nub_error;
 

--- a/src/xi_nub.h
+++ b/src/xi_nub.h
@@ -1,0 +1,87 @@
+/*
+ * xi (aka ξ), a search tool for the Unicode Character Database.
+ *
+ * Copyright (c) 2020 Michael Clark <michaeljclark@mac.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+/*
+ * const char* argv[] = { "Xi", "nub-server" };
+ *
+ * xi_nub_server *server = xi_nub_server_new(argc, argv);
+ * xi_nub_accept(server, myaccept_cb);
+ *
+ * xi_nub_client *client = xi_nub_client_new(argc, argv)
+ * xi_nub_connect(client, myconnect_cb)
+ *
+ * xi_nub_conn_read(conn, err, buf, len, myread_cb)
+ * xi_nub_conn_write(conn, err, buf, len, mywrite_cb)
+ * xi_nub_conn_close(conn, err, myclose_cb)
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct xi_nub_ctx;
+struct xi_nub_server;
+struct xi_nub_client;
+struct xi_nub_conn;
+
+typedef enum
+{
+	xi_nub_success,
+	xi_nub_einval,
+	xi_nub_econnrefused,
+	xi_nub_egeneric = 255
+} xi_nub_error;
+
+typedef void(*xi_nub_accept_cb)(xi_nub_conn *conn, xi_nub_error err);
+typedef void(*xi_nub_connect_cb)(xi_nub_conn *conn, xi_nub_error err);
+typedef void(*xi_nub_read_cb)(xi_nub_conn *conn, xi_nub_error err, void *buf, size_t len);
+typedef void(*xi_nub_write_cb)(xi_nub_conn *conn, xi_nub_error err, void *buf, size_t len);
+typedef void(*xi_nub_close_cb)(xi_nub_conn *conn, xi_nub_error err);
+
+void xi_nub_init(xi_nub_ctx *ctx);
+
+/* nub server */
+xi_nub_server* xi_nub_server_new(xi_nub_ctx *ctx, int argc, const char **argv);
+void xi_nub_server_accept(xi_nub_server *server, int nthreads, xi_nub_accept_cb cb);
+
+/* nub client */
+xi_nub_client* xi_nub_client_new(xi_nub_ctx *ctx, int argc, const char **argv);
+void xi_nub_client_connect(xi_nub_client *client, int nthreads, xi_nub_connect_cb cb);
+
+/* nub connection */
+void xi_nub_conn_read(xi_nub_conn *conn, void *buf, size_t len, xi_nub_read_cb cb);
+void xi_nub_conn_write(xi_nub_conn *conn, void *buf, size_t len, xi_nub_write_cb cb);
+void xi_nub_conn_close(xi_nub_conn *conn, xi_nub_close_cb cb);
+void xi_nub_conn_set_user_data(xi_nub_conn *conn, void *data);
+void* xi_nub_conn_get_user_data(xi_nub_conn *conn);
+xi_nub_client* xi_nub_conn_get_client(xi_nub_conn *conn);
+xi_nub_server* xi_nub_conn_get_server(xi_nub_conn *conn);
+xi_nub_ctx* xi_nub_conn_get_context(xi_nub_conn *conn);
+const char* xi_nub_conn_get_identity(xi_nub_conn *conn);
+
+/* nub context */
+xi_nub_ctx* xi_nub_ctx_get_root_context();
+const char* xi_nub_ctx_get_profile_path(xi_nub_ctx *ctx);
+void xi_nub_ctx_set_user_data(xi_nub_ctx *ctx, void *data);
+void* xi_nub_ctx_get_user_data(xi_nub_ctx *ctx);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/test_exe.cc
+++ b/tests/test_exe.cc
@@ -1,0 +1,21 @@
+/*
+ * test_sem.cc
+ */
+
+#undef NDEBUG
+#include <cstdio>
+#include <cassert>
+#include <cinttypes>
+
+#include "xi_common.h"
+
+void test_executable_path()
+{
+	std::string path = _executable_path();
+	printf("%s\n", path.c_str());
+}
+
+int main()
+{
+	test_executable_path();
+}

--- a/tests/test_sem.cc
+++ b/tests/test_sem.cc
@@ -47,12 +47,6 @@ int test_sem_cb(void*)
 	return 5;
 }
 
-static void msleep(int millis)
-{
-    struct timespec tv = { millis / 1000, (millis % 1000) * 1000000 };
-    thrd_sleep(&tv, NULL);
-}
-
 void test_sem()
 {
 	thrd_t t;
@@ -67,7 +61,7 @@ void test_sem()
 
 	t1 = _clock_time_ns();
 	thrd_create(&t, &test_sem_cb, NULL);
-	msleep(300);
+	_thread_sleep(300);
 	_semaphore_signal(&test_sem1);
 	thrd_join(t, &res);
 	t4 = _clock_time_ns();

--- a/tests/test_sem.cc
+++ b/tests/test_sem.cc
@@ -1,0 +1,92 @@
+/*
+ * test_sem.cc
+ */
+
+#undef NDEBUG
+#include <cassert>
+#include <cinttypes>
+#include <threads.h>
+
+#include "xi_nub.h"
+#include "xi_common.h"
+
+void test_lock()
+{
+    char sem_file[MAXPATHLEN];
+    xi_nub_ctx* ctx = xi_nub_ctx_get_root_context();
+    const char* profile_path = xi_nub_ctx_get_profile_path(ctx);
+    snprintf(sem_file, sizeof(sem_file), "%s%s", profile_path,
+        PATH_SEPARATOR "semaphore");
+
+    bool is_leader = false;
+    auto f = _open_file(sem_file, file_create_new, file_append);
+    if (f.has_error()) {
+        f = _open_file(sem_file, file_open_existing, file_append);
+    } else {
+        is_leader = true;
+    }
+    uint32_t pid = (uint32_t)_get_processs_id();
+    _write(&f, &pid, sizeof(pid));
+    xi_nub_result off = _get_file_offset(&f);
+    uint32_t ticket = (uint32_t)off.bytes >> 2;
+    _close(&f);
+
+    printf("%s: ticket=%u, is_leader=%u, pid=%u, file=%s\n",
+    	__func__, ticket, is_leader, pid, sem_file);
+}
+
+static uint64_t t1, t2, t3, t4;
+static xi_nub_platform_semaphore test_sem1;
+
+int test_sem_cb(void*)
+{
+	t2 = _clock_time_ns();
+	_semaphore_wait(&test_sem1, 1000);
+	printf("%s: woke\n", __func__);
+	t3 = _clock_time_ns();
+	return 5;
+}
+
+static void msleep(int millis)
+{
+    struct timespec tv = { millis / 1000, (millis % 1000) * 1000000 };
+    thrd_sleep(&tv, NULL);
+}
+
+void test_sem()
+{
+	thrd_t t;
+	int res;
+	static const char *sem_name = "test_sem1";
+
+	test_sem1 = _semaphore_create(sem_name);
+	if (test_sem1.has_error() && test_sem1.error_code() == xi_nub_eexist) {
+		test_sem1 = _semaphore_open(sem_name);
+	}
+	assert(!test_sem1.has_error());
+
+	t1 = _clock_time_ns();
+	thrd_create(&t, &test_sem_cb, NULL);
+	msleep(300);
+	_semaphore_signal(&test_sem1);
+	thrd_join(t, &res);
+	t4 = _clock_time_ns();
+
+	_semaphore_close(&test_sem1);
+	_semaphore_unlink(sem_name);
+
+	printf("t1=%" PRId64 "ns t2=%" PRId64 "ns\n", (t3-t2), (t4-t1));
+
+	const uint64_t MS = 1000000;
+	assert(res == 5);
+	assert((t3-t2) < 350 * MS);
+	assert((t3-t2) > 250 * MS);
+	assert((t4-t1) < 350 * MS);
+	assert((t4-t1) > 250 * MS);
+}
+
+int main()
+{
+	test_lock();
+	test_sem();
+}

--- a/tests/test_sem.cc
+++ b/tests/test_sem.cc
@@ -35,6 +35,28 @@ void test_lock()
     	__func__, ticket, is_leader, pid, sem_file);
 }
 
+void test_unlock()
+{
+    char sem_file[MAXPATHLEN];
+    xi_nub_ctx* ctx = xi_nub_ctx_get_root_context();
+    const char* profile_path = xi_nub_ctx_get_profile_path(ctx);
+    snprintf(sem_file, sizeof(sem_file), "%s%s", profile_path,
+        PATH_SEPARATOR "semaphore");
+
+    auto f = _open_file(sem_file, file_open_existing, file_read_write);
+    assert (!f.has_error());
+
+    char buf[1024];
+	xi_nub_result r = _read(&f, buf, sizeof(buf));
+	size_t num_waiters = (size_t)(r.bytes >> 2);
+	uint32_t *p = (uint32_t*)buf;
+	for (size_t i = 0; i < num_waiters; i++) {
+		uint32_t pid = *p++;
+		printf("ticket-%zu: pid=%d\n", i, pid);
+	}
+	_close(&f);
+}
+
 static uint64_t t1, t2, t3, t4;
 static xi_nub_platform_semaphore test_sem1;
 
@@ -82,5 +104,6 @@ void test_sem()
 int main()
 {
 	test_lock();
+	test_unlock();
 	test_sem();
 }


### PR DESCRIPTION
## nubs 
nubs allow splitting the app into a client and server part, with the server automatically started by the nub client. a nub is like a combination of _connect_, _if-fail_ _maybe-fork_, _connect_. the nub server lifecycle is distinct from the nub client. subsequent invocations will connect to a process launched by an earlier invocation. nubs are intended to allow forking a cache process, which in this case is the Rabin-Karp index. this speeds up successive searches by a large factor.

### nub locking
a locking protocol is used to ensure that only a single process is launched. clients attempt to connect to the server. if it is not listening, they will create a semaphore, writing the id to a file, and then wait on it. the first client will fork a server process. when the server has started, it will read the list of semaphores and signal them waking up all of the clients.